### PR TITLE
feat(api): ✨ add media deletion feature with user validation oc:5879

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -47,6 +47,9 @@ Route::name('ugc.')->prefix('ugc')->middleware('auth:api')->group(function () {
         Route::post('edit', [UgcTrackController::class, 'legacyUpdate'])->name('update.legacy');
         Route::get('delete/{track}', [UgcTrackController::class, 'destroy'])->name('destroy.legacy');
     });
+    Route::prefix('media')->name('media.')->group(function () {
+        Route::get('delete/{media}', [MediaController::class, 'destroy'])->name('destroy.legacy');
+    });
 });
 
 // ####################  ###########################

--- a/src/Http/Controllers/Api/MediaController.php
+++ b/src/Http/Controllers/Api/MediaController.php
@@ -2,6 +2,7 @@
 
 namespace Wm\WmPackage\Http\Controllers\Api;
 
+use Exception;
 use Illuminate\Http\JsonResponse;
 use Wm\WmPackage\Http\Controllers\Controller;
 use Wm\WmPackage\Http\Resources\MediaResource;
@@ -18,5 +19,20 @@ class MediaController extends Controller
         $geojson['properties'] = new MediaResource($media)->toArray();
 
         return response()->json($geojson);
+    }
+
+    public function destroy(Media $media): JsonResponse
+    {
+        $this->validateUser($media);
+        try {
+            $media->delete();
+        } catch (Exception $e) {
+            return response()->json([
+                'error' => "this media can't be deleted by api",
+                'code' => 400,
+            ], 400);
+        }
+
+        return response()->json(['success' => 'media deleted']);
     }
 }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Validator;
 use Wm\WmPackage\Models\Abstracts\GeometryModel;
+use Wm\WmPackage\Models\Interfaces\UserOwnedModelInterface;
 
 /**
  * @OA\Info(
@@ -82,7 +83,7 @@ class Controller extends BaseController
         return $data;
     }
 
-    protected function validateUser(GeometryModel $model)
+    protected function validateUser(UserOwnedModelInterface $model)
     {
         // TODO: skip this when there will be better model policies
         $user = auth()->user();

--- a/src/Models/Interfaces/UserOwnedModelInterface.php
+++ b/src/Models/Interfaces/UserOwnedModelInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Wm\WmPackage\Models\Interfaces;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+interface UserOwnedModelInterface
+{
+    /**
+     * Scope a query to only include current user models.
+     */
+    public function scopeCurrentUser(Builder $query): Builder;
+
+    /**
+     * Get the user that owns the model.
+     */
+    public function user(): BelongsTo;
+
+    /**
+     * Alias for the user relation.
+     */
+    public function author(): BelongsTo;
+}

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -6,12 +6,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Spatie\MediaLibrary\MediaCollections\Models\Media as SpatieMedia;
+use Wm\WmPackage\Models\Interfaces\UserOwnedModelInterface;
 use Wm\WmPackage\Observers\MediaObserver;
 use Wm\WmPackage\Services\GeoJsonService;
 use Wm\WmPackage\Traits\HasPackageFactory;
 use Wm\WmPackage\Traits\OwnedByUserModel;
 
-class Media extends SpatieMedia
+class Media extends SpatieMedia implements UserOwnedModelInterface
 {
     use HasPackageFactory, OwnedByUserModel;
 

--- a/src/Models/UgcPoi.php
+++ b/src/Models/UgcPoi.php
@@ -4,6 +4,7 @@ namespace Wm\WmPackage\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Wm\WmPackage\Models\Abstracts\Point;
+use Wm\WmPackage\Models\Interfaces\UserOwnedModelInterface;
 use Wm\WmPackage\Observers\UgcObserver;
 use Wm\WmPackage\Traits\OwnedByUserModel;
 
@@ -20,7 +21,7 @@ use Wm\WmPackage\Traits\OwnedByUserModel;
  * @property string raw_data
  * @property mixed  ugc_media
  */
-class UgcPoi extends Point
+class UgcPoi extends Point implements UserOwnedModelInterface
 {
     use OwnedByUserModel;
 

--- a/src/Models/UgcTrack.php
+++ b/src/Models/UgcTrack.php
@@ -4,6 +4,7 @@ namespace Wm\WmPackage\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Wm\WmPackage\Models\Abstracts\MultiLineString;
+use Wm\WmPackage\Models\Interfaces\UserOwnedModelInterface;
 use Wm\WmPackage\Observers\UgcObserver;
 use Wm\WmPackage\Traits\OwnedByUserModel;
 
@@ -19,7 +20,7 @@ use Wm\WmPackage\Traits\OwnedByUserModel;
  * @property string description
  * @property string raw_data
  */
-class UgcTrack extends MultiLineString
+class UgcTrack extends MultiLineString implements UserOwnedModelInterface
 {
     use OwnedByUserModel;
 

--- a/src/Traits/OwnedByUserModel.php
+++ b/src/Traits/OwnedByUserModel.php
@@ -3,6 +3,7 @@
 namespace Wm\WmPackage\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Wm\WmPackage\Models\User;
 
 trait OwnedByUserModel
@@ -18,12 +19,12 @@ trait OwnedByUserModel
     /**
      * Alias for the user relation
      */
-    public function author()
+    public function author(): BelongsTo
     {
         return $this->user();
     }
 
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }


### PR DESCRIPTION
Added a new route for deleting media entries within the UGC prefix group, allowing authenticated users to delete media if they are the owners. Implemented a new `UserOwnedModelInterface` to enforce user ownership checks on models. Updated the `Media`, `UgcPoi`, and `UgcTrack` models to implement this interface, and adjusted the `validateUser` method in the `Controller` to utilize this interface.

- Introduced a `destroy` method in `MediaController` for handling deletion requests.
- Added exception handling to provide a clear error response if deletion fails.
- Implemented `OwnedByUserModel` trait to manage user associations and query scopes.
- Updated `Media`, `UgcPoi`, and `UgcTrack` to conform to `UserOwnedModelInterface`.
- Updated routing in `api.php` to support media deletion.

These changes ensure that media can be securely deleted by authenticated users who own the media, enhancing the system's data management capabilities.
