### PR TITLE
refactor(metrics): ♻️ optimize top UGC creators query OC. 6077

### DIFF
--- a/src/Nova/Metrics/TopUgcCreators.php
+++ b/src/Nova/Metrics/TopUgcCreators.php
@@ -37,6 +37,15 @@ class TopUgcCreators extends Table
         $ugcTable = (new $this->ugcModelClass)->getTable();
         $userTable = (new AppUser)->getTable();
 
+        $bestUserIds = DB::table("{$ugcTable}")
+            ->select('user_id', DB::raw('COUNT(*) as total'))
+            ->whereNotNull('user_id')
+            ->groupBy('user_id')
+            ->orderByDesc('total')
+            ->limit(5)
+            ->pluck('user_id');
+
+        // passo 2: join solo per quei 5 utenti
         $topUsers = DB::table("{$ugcTable} as ugc")
             ->select(
                 'ugc.user_id',
@@ -45,10 +54,9 @@ class TopUgcCreators extends Table
                 'u.email'
             )
             ->join("{$userTable} as u", 'u.id', '=', 'ugc.user_id')
-            ->whereNotNull('ugc.user_id')
+            ->whereIn('ugc.user_id', $bestUserIds)
             ->groupBy('ugc.user_id', 'u.name', 'u.email')
             ->orderByDesc('total')
-            ->limit(5)
             ->get();
 
         if ($topUsers->isEmpty()) {


### PR DESCRIPTION
- Extracted the top 5 user IDs with the highest UGC count into a separate query using `pluck`.
- Modified the join query to filter results using these top user IDs.
- Removed the redundant limit from the join query since filtering is now based on pre-selected user IDs.
