### PR TITLE
refactor(models): ♻️ move GeoJSON methods to GeometryModel OC_6134

### DIFF
--- a/resources/views/widgets/feature-collection-map.blade.php
+++ b/resources/views/widgets/feature-collection-map.blade.php
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="it">
+
+<head>
+    <meta charset="utf-8">
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Feature Collection Widget Map</title>
+    <link rel="stylesheet"
+        href="https://cdn.statically.io/gh/webmappsrl/feature-collection-widget-map/refs/heads/master/dist_20_08_2025/styles.css">
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: Arial, sans-serif;
+        }
+
+        .container {
+            width: 100%;
+            height: 100vh;
+        }
+
+        feature-collection-widget-map {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <feature-collection-widget-map geojsonurl="{{ $geojsonUrl }}" strokeColor="rgba(0, 0, 255, 1)" strokeWidth="3"
+            pointStrokeColor="rgba(0, 0, 255, 1)" pointStrokeWidth="3" fillColor="rgba(0, 0, 255, 0.3)"
+            showControlZoom="true" mouseWheelZoom="true" dragPan="true" padding="50">
+        </feature-collection-widget-map>
+    </div>
+
+    <!-- Script Angular -->
+    <script
+        src="https://cdn.statically.io/gh/webmappsrl/feature-collection-widget-map/refs/heads/master/dist_20_08_2025/runtime.js">
+    </script>
+    <script
+        src="https://cdn.statically.io/gh/webmappsrl/feature-collection-widget-map/refs/heads/master/dist_20_08_2025/polyfills.js">
+    </script>
+    <script
+        src="https://cdn.statically.io/gh/webmappsrl/feature-collection-widget-map/refs/heads/master/dist_20_08_2025/main.js">
+    </script>
+</body>
+
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,3 +30,38 @@ Route::post('import/confirm', [ImportController::class, 'saveImport'])->name('sa
 Route::get('/password/reset', function () {
     return redirect('/nova/password/reset');
 });
+
+// Widget Feature Collection Map
+Route::get('widget/feature-collection-map', function () {
+    $geojsonUrl = request()->get('geojson', 'https://sis-te.com/api/v1/catalog/geohub/1.geojson');
+
+    return view('wm-package::widgets.feature-collection-map', ['geojsonUrl' => $geojsonUrl]);
+})->name('widget.feature-collection-map');
+
+// GeoJSON endpoint for hiking route and poles feature collection
+Route::get('widget/feature-collection-map-url/{model}/{id}', function ($model, $id) {
+    $geojson = null;
+
+    // Usa i modelli configurati nel package o fallback ai modelli di default
+    switch ($model) {
+        case 'hiking-route':
+            $modelClass = config('wm-package.models.hiking_route', 'App\Models\HikingRoute');
+            if (class_exists($modelClass)) {
+                $hikingRoute = $modelClass::findOrFail($id);
+                $geojson = $hikingRoute->getFeatureCollectionMap();
+            }
+            break;
+        case 'poles':
+            $modelClass = config('wm-package.models.poles', 'App\Models\Poles');
+            if (class_exists($modelClass)) {
+                $pole = $modelClass::findOrFail($id);
+                $geojson = $pole->getFeatureCollectionMap();
+            }
+            break;
+        default:
+            $geojson = null;
+            break;
+    }
+
+    return response()->json($geojson);
+})->name('widget.feature-collection-map-url');

--- a/src/Models/Abstracts/GeometryModel.php
+++ b/src/Models/Abstracts/GeometryModel.php
@@ -4,6 +4,7 @@ namespace Wm\WmPackage\Models\Abstracts;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\DB;
 use Spatie\Image\Enums\Fit;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
@@ -178,5 +179,51 @@ abstract class GeometryModel extends Model implements HasMedia
         // add options
         // you can define as many collections as needed
         $this->addMediaCollection('default');
+    }
+
+    /**
+     * Get track as GeoJSON feature collection for map widget
+     *
+     * @return array GeoJSON feature collection
+     */
+    public function getFeatureCollectionMap(): array
+    {
+        if (! $this->geometry) {
+            return [
+                'type' => 'FeatureCollection',
+                'features' => [],
+            ];
+        }
+
+        // Converti WKB in GeoJSON usando PostGIS
+        $geojson = DB::select("SELECT ST_AsGeoJSON(ST_GeomFromWKB(decode(?, 'hex'))) as geojson", [$this->geometry]);
+
+        if (empty($geojson)) {
+            return [
+                'type' => 'FeatureCollection',
+                'features' => [],
+            ];
+        }
+        $feature = $this->getFeatureMap();
+        $feature['properties'] = $this->properties;
+
+        return [
+            'type' => 'FeatureCollection',
+            'features' => [$feature],
+        ];
+    }
+
+    public function getFeatureMap($geometry = null)
+    {
+        if ($geometry === null) {
+            $geometry = $this->geometry;
+        }
+        $geojson = DB::select("SELECT ST_AsGeoJSON(ST_GeomFromWKB(decode(?, 'hex'))) as geojson", [$geometry]);
+        $geometry = json_decode($geojson[0]->geojson, true);
+
+        return [
+            'type' => 'Feature',
+            'geometry' => $geometry,
+        ];
     }
 }

--- a/src/Models/EcTrack.php
+++ b/src/Models/EcTrack.php
@@ -51,7 +51,7 @@ class EcTrack extends MultiLineString implements LayerRelatedModel
 
     protected static function booted()
     {
-        self::observe(EcTrackObserver::class);
+        EcTrack::observe(EcTrackObserver::class);
 
         // Imposta un default per properties se è null
         static::creating(function ($model) {

--- a/src/Models/EcTrack.php
+++ b/src/Models/EcTrack.php
@@ -51,7 +51,7 @@ class EcTrack extends MultiLineString implements LayerRelatedModel
 
     protected static function booted()
     {
-        EcTrack::observe(EcTrackObserver::class);
+        self::observe(EcTrackObserver::class);
 
         // Imposta un default per properties se è null
         static::creating(function ($model) {
@@ -558,13 +558,11 @@ class EcTrack extends MultiLineString implements LayerRelatedModel
 
     public function toSearchableArray()
     {
-
         $ecTrackService = EcTrackService::make();
         $mediaService = MediaService::make();
         $firstMedia = $this->getMedia('*')->first();
 
         try {
-
             [$start, $end] = GeometryComputationService::make()->getStartEndCoordinates($this);
         } catch (\Exception $e) {
             $start = [0, 0];
@@ -624,7 +622,6 @@ class EcTrack extends MultiLineString implements LayerRelatedModel
             $string .= $this->properties['ref'].' ';
         }
         if (isset($this->properties['osmid']) && empty($searchables) || (in_array('osmid', $searchables) && ! empty($this->properties['osmid']))) {
-
             $string .= $this->properties['osmid'].' ';
         }
 
@@ -635,50 +632,5 @@ class EcTrack extends MultiLineString implements LayerRelatedModel
         }
 
         return html_entity_decode($string);
-    }
-
-    /**
-     * Get track as GeoJSON feature collection for map widget
-     *
-     * @return array GeoJSON feature collection
-     */
-    public function getFeatureCollectionMap(): array
-    {
-        if (! $this->geometry) {
-            return [
-                'type' => 'FeatureCollection',
-                'features' => []
-            ];
-        }
-
-        // Converti WKB in GeoJSON usando PostGIS
-        $geojson = DB::select("SELECT ST_AsGeoJSON(ST_GeomFromWKB(decode(?, 'hex'))) as geojson", [$this->geometry]);
-        
-        if (empty($geojson)) {
-            return [
-                'type' => 'FeatureCollection',
-                'features' => []
-            ];
-        }
-        $feature = $this->getFeatureMap();
-        $feature['properties'] = $this->properties;
-
-        return [
-            'type' => 'FeatureCollection',
-            'features' => [$feature]
-        ];
-    }
-
-    public function getFeatureMap($geometry = null) {
-        if ($geometry === null) {
-            $geometry = $this->geometry;
-        }
-        $geojson = DB::select("SELECT ST_AsGeoJSON(ST_GeomFromWKB(decode(?, 'hex'))) as geojson", [$geometry]);
-        $geometry = json_decode($geojson[0]->geojson, true);
-
-        return [
-            'type' => 'Feature',
-            'geometry' => $geometry,
-        ];
     }
 }

--- a/src/Nova/Fields/FeatureCollectionMap.php
+++ b/src/Nova/Fields/FeatureCollectionMap.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Wm\WmPackage\Nova\Fields;
+
+use Laravel\Nova\Fields\Text;
+
+class FeatureCollectionMap extends Text
+{
+    protected $modelType;
+
+    /**
+     * Create a new field.
+     *
+     * @param  string  $name
+     * @param  string|callable|null  $attribute
+     * @return void
+     */
+    public function __construct($name, $attribute = null, ?callable $resolveCallback = null)
+    {
+        parent::__construct($name, $attribute, $resolveCallback);
+
+        // Configura automaticamente il field
+        $this->configureField();
+    }
+
+    /**
+     * Set the model type for hiking routes.
+     *
+     * @return $this
+     */
+    public function forHikingRoute()
+    {
+        $this->modelType = 'hiking-route';
+
+        return $this;
+    }
+
+    /**
+     * Set the model type for poles.
+     *
+     * @return $this
+     */
+    public function forPoles()
+    {
+        $this->modelType = 'poles';
+
+        return $this;
+    }
+
+    /**
+     * Configure the field with default settings.
+     *
+     * @return $this
+     */
+    protected function configureField()
+    {
+        return $this
+            ->resolveUsing(function ($value, $resource) {
+                // Se non è specificato un modelType, prova a inferirlo dal nome della risorsa
+                if (! $this->modelType) {
+                    $this->modelType = $this->inferModelType(get_class($resource));
+                }
+
+                // Genera l'URL per il GeoJSON dinamico basato sull'ID del record
+                $geojsonUrl = url("/widget/feature-collection-map-url/{$this->modelType}/{$resource->id}");
+
+                return <<<HTML
+                        <div style="min-height: 400px; position: relative;background: white;">
+                            <iframe 
+                                src="/widget/feature-collection-map?geojson={$geojsonUrl}"
+                                style="width: 100%; height: 500px; border: none; border-radius: 4px;"
+                                frameborder="0"
+                                allowfullscreen>
+                            </iframe>
+                        </div>
+                    HTML;
+            })
+            ->asHtml()
+            ->onlyOnDetail();
+    }
+
+    /**
+     * Infer the model type from the resource class name.
+     */
+    protected function inferModelType($resourceClass): string
+    {
+        $modelName = class_basename($resourceClass);
+
+        return match (true) {
+            str_contains($modelName, 'HikingRoute') => 'hiking-route',
+            str_contains($modelName, 'Poles') => 'poles',
+            default => 'hiking-route', // default fallback
+        };
+    }
+}


### PR DESCRIPTION
- Moved `getFeatureCollectionMap` and `getFeatureMap` methods from `EcTrack` to `GeometryModel` to promote code reuse and maintainability.
- Updated `GeometryModel` to include necessary imports and ensure proper functionality of the moved methods.
- Removed redundant methods from `EcTrack`, simplifying the class and avoiding code duplication.
- Ensured that the new implementation maintains the same functionality and output as the old one.