### PR TITLE
feat(import): ✨ add SVG to name icon transformation oc:6202

### DIFF
--- a/config/wm-geohub-import.php
+++ b/config/wm-geohub-import.php
@@ -493,6 +493,7 @@ return [
                 'identifier' => 'properties->geohub_id',
                 'created_at' => 'created_at',
                 'updated_at' => 'updated_at',
+                'icon' => ['field' => 'icon', 'transformer' => [DataTransformer::class, 'svgIconToNameIcon']],
             ],
             'properties' => [
                 'column_name' => 'properties',

--- a/src/Services/Import/DataTransformer.php
+++ b/src/Services/Import/DataTransformer.php
@@ -4,6 +4,7 @@ namespace Wm\WmPackage\Services\Import;
 
 use Carbon\Carbon;
 use Illuminate\Support\Str;
+use Wm\WmPackage\Services\Import\IconMappingService;
 
 class DataTransformer
 {
@@ -204,5 +205,14 @@ class DataTransformer
         }
 
         return json_encode($properties);
+    }
+
+    public function svgIconToNameIcon(?string $svg): ?string
+    {
+        if (! $svg) {
+            return null;
+        }
+
+        return app(IconMappingService::class)->getSvgIdentifier($svg);
     }
 }

--- a/src/Services/Import/IconMappingService.php
+++ b/src/Services/Import/IconMappingService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Wm\WmPackage\Services\Import;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Wm\WmPackage\Services\StorageService;
+
+class IconMappingService
+{
+    private const CACHE_KEY = 'geohub_icons_mapping';
+
+    private const DEFAULT_HEIGHT = 1024;
+
+    private const DEFAULT_PREV_SIZE = 32;
+
+    private const CACHE_TTL = 86400;
+
+    private StorageService $storageService;
+
+    public function __construct(StorageService $storageService)
+    {
+        $this->storageService = $storageService;
+    }
+
+    public function getIconMapping(): array
+    {
+        return Cache::remember(self::CACHE_KEY, self::CACHE_TTL, function () {
+            $app = DB::connection('geohub')
+                ->table('apps')
+                ->where('id', 3)
+                ->whereNotNull('iconmoon_selection')
+                ->first(['iconmoon_selection']);
+
+            $mapping = [];
+
+            $this->storageService->storeIcons($app->iconmoon_selection);
+
+            $iconmoonData = json_decode($app->iconmoon_selection, true);
+            if (! $iconmoonData || ! isset($iconmoonData['icons'])) {
+                return $mapping;
+            }
+
+            $height = self::DEFAULT_HEIGHT;
+            $prevSize = self::DEFAULT_PREV_SIZE;
+            $height2 = $height / 2;
+
+            foreach ($iconmoonData['icons'] as $icon) {
+                if (! isset($icon['icon']['paths'])) {
+                    continue;
+                }
+
+                $svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 {$height} {$height}' width='{$prevSize}' height='{$prevSize}'><circle fill=\"darkorange\"  cx='{$height2}' cy='{$height2}' r='{$height2}'/><g fill=\"white\" transform='scale(0.8 0.8) translate(100, 100)'>";
+                foreach ($icon['icon']['paths'] as $path) {
+                    $svg .= "<path d='{$path}'/>";
+                }
+                $svg .= '</g></svg>';
+
+                $mapping[$svg] = $icon['properties']['name'];
+            }
+
+            return $mapping;
+        });
+    }
+
+    public function getSvgIdentifier(string $svg): ?string
+    {
+        if (! $svg) {
+            return null;
+        }
+
+        $mapping = $this->getIconMapping();
+        if (isset($mapping[$svg])) {
+            return $mapping[$svg];
+        }
+
+        return null;
+    }
+}

--- a/src/Services/StorageService.php
+++ b/src/Services/StorageService.php
@@ -16,6 +16,13 @@ class StorageService extends BaseService
         return $this->getRemoteWfeDisk()->put($path, $contents) ? $path : false;
     }
 
+    public function storeIcons(string $contents): string|false
+    {
+        $path = $this->getIconsPath();
+
+        return $this->getRemoteWfeDisk()->put($path, $contents) ? $path : false;
+    }
+
     public function getTrackGeojson(int $trackId, int $appId): ?string
     {
         return $this->getRemoteWfeDisk()->get($this->getTrackPath($trackId));
@@ -262,6 +269,11 @@ class StorageService extends BaseService
     private function getTrackPath(int $trackId): string
     {
         return $this->getShardBasePath()."tracks/{$trackId}.json";
+    }
+
+    private function getIconsPath(): string
+    {
+        return $this->getShardBasePath().'json/icons.json';
     }
 
     private function getAppConfigPath(int $appId): string


### PR DESCRIPTION
Added a new feature to convert SVG icons to their respective name identifiers using a new `IconMappingService`. This service caches the icon mapping data and retrieves the name based on the SVG content.

- Introduced `svgIconToNameIcon` method in `DataTransformer` to handle the transformation.
- Added `IconMappingService` to manage fetching and caching of icon mappings from the database.
- Enhanced `StorageService` with a new method `storeIcons` to store icon data.
- Updated configurations to utilize the new transformation logic.

This enhancement streamlines the process of handling icon data by mapping SVG content to recognizable names, thus improving maintainability and readability of icon-related operations.
