### PR TITLE
feat(jobs): ✨ add UpdateEcPoiAwsJob for AWS integration oc: 6286

### DIFF
--- a/src/Jobs/UpdateEcPoiAwsJob.php
+++ b/src/Jobs/UpdateEcPoiAwsJob.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Wm\WmPackage\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Queue\SerializesModels;
+use Wm\WmPackage\Models\EcPoi;
+use Wm\WmPackage\Services\StorageService;
+
+class UpdateEcPoiAwsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(protected EcPoi $ecPoi)
+    {
+        $this->onQueue('aws');
+    }
+
+    /**
+     * Definisci i middleware per il job.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return [
+            // Applica WithoutOverlapping con una chiave unica per limitare la concorrenza
+            new WithoutOverlapping($this->getLockKey()),
+        ];
+    }
+
+    /**
+     * Genera una chiave unica per il lock di WithoutOverlapping.
+     *
+     * @return string
+     */
+    protected function getLockKey()
+    {
+        // Utilizza un identificatore unico per ogni POI
+        return 'upload-ecpoi-to-aws-'.$this->ecPoi->id;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(StorageService $cloudStorageService)
+    {
+        // Ottieni il modello dalla configurazione per essere consistente
+        $ecPoiModelClass = config('wm-package.ec_poi_model', EcPoi::class);
+
+        // Ricarica il modello usando la classe configurata per assicurarsi che sia della classe corretta
+        $ecPoi = $ecPoiModelClass::find($this->ecPoi->id);
+
+        if (! $ecPoi) {
+            throw new \Exception("EcPoi with ID {$this->ecPoi->id} not found");
+        }
+
+        // Recupera l'App associata all'EcPoi
+        $app = $ecPoi->app;
+
+        if (! $app) {
+            throw new \Exception("App not found for EcPoi with ID {$ecPoi->id}");
+        }
+
+        // Genera il GeoJSON di tutti i POI dell'app e salvalo su AWS
+        $app->BuildPoisGeojson();
+    }
+}

--- a/src/Services/Models/EcPoiService.php
+++ b/src/Services/Models/EcPoiService.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Throwable;
+use Wm\WmPackage\Jobs\UpdateEcPoiAwsJob;
 use Wm\WmPackage\Jobs\UpdateEcPoiDemJob;
 use Wm\WmPackage\Jobs\UpdateModelWithGeometryTaxonomyWhere;
 use Wm\WmPackage\Models\Abstracts\GeometryModel;
@@ -17,21 +18,20 @@ class EcPoiService extends BaseService
 {
     public function updateDataChain(EcPoi $model)
     {
+        $chain = [];
 
         if ($model->wasChanged('geometry')) {
-
-            $chain = [
-
-                new UpdateModelWithGeometryTaxonomyWhere($model), // it relates where taxonomy terms to the media model based on geometry attribute
-                new UpdateEcPoiDemJob($model),
-            ];
-
-            Bus::chain($chain)
-                ->catch(function (Throwable $e) {
-                    // A job within the chain has failed...
-                    Log::error($e->getMessage());
-                })->dispatch();
+            $chain[] = new UpdateModelWithGeometryTaxonomyWhere($model); // it relates where taxonomy terms to the media model based on geometry attribute
+            $chain[] = new UpdateEcPoiDemJob($model);
         }
+
+        $chain[] = new UpdateEcPoiAwsJob($model);
+
+        Bus::chain($chain)
+            ->catch(function (Throwable $e) {
+                // A job within the chain has failed...
+                Log::error($e->getMessage());
+            })->dispatch();
     }
 
     public function getUpdatedAtPois(?int $app_id = null): Collection
@@ -39,7 +39,6 @@ class EcPoiService extends BaseService
         if ($app_id) {
             $arr = EcPoi::where('app_id', $app_id)->pluck('updated_at', 'id');
         } else {
-
             $arr = DB::select('select id, updated_at from ec_pois');
             $arr = collect($arr)->pluck('updated_at', 'id');
         }


### PR DESCRIPTION
Introduce a new job `UpdateEcPoiAwsJob` to handle the uploading of POIs to AWS. This job ensures that each POI is processed with a unique lock key to prevent concurrency issues. Additionally, it reloads the model using the configured class to guarantee type consistency and throws an exception if the associated EcPoi or App is not found.

The job leverages the `BuildPoisGeojson` method of the App model to generate and upload GeoJSON data of all POIs to AWS.

refactor(services): ♻️ integrate UpdateEcPoiAwsJob into EcPoiService

Updated `EcPoiService` to incorporate the new `UpdateEcPoiAwsJob` into the job chain within `updateDataChain` method. This ensures that after updating the geometry, the POI data is also processed for AWS upload. The job chain is built dynamically based on the model's changes, and any exceptions are logged for troubleshooting.
