### PR TITLE
feat(observer): ✨ add Artisan queue for building POIs GeoJSON oc:6286

### DIFF
--- a/src/Commands/WmBuildAppPoisGeojsonCommand.php
+++ b/src/Commands/WmBuildAppPoisGeojsonCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Wm\WmPackage\Commands;
+
+use Illuminate\Console\Command;
+use Wm\WmPackage\Models\App;
+
+class WmBuildAppPoisGeojsonCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'wm:build-pois-geojson {app_id : The ID of the app}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Build pois.geojson file for a specific app';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $appId = $this->argument('app_id');
+
+        $this->info("Generando pois.geojson per App ID: {$appId}");
+
+        // Trova l'app
+        $app = App::find($appId);
+        if (! $app) {
+            $this->error("App con ID {$appId} non trovata!");
+
+            return 1;
+        }
+
+        $this->info("App trovata: {$app->name}");
+
+        // Genera il geojson usando il metodo dell'App
+        $geojson = $app->BuildPoisGeojson();
+
+        $this->info("✅ File pois.geojson generato con successo per App {$appId}");
+        $this->info('📊 Features generate: '.count($geojson['features']));
+
+        return 0;
+
+        return 0;
+    }
+}

--- a/src/Commands/WmBuildAppPoisGeojsonCommand.php
+++ b/src/Commands/WmBuildAppPoisGeojsonCommand.php
@@ -47,7 +47,5 @@ class WmBuildAppPoisGeojsonCommand extends Command
         $this->info('📊 Features generate: '.count($geojson['features']));
 
         return 0;
-
-        return 0;
     }
 }

--- a/src/Observers/EcPoiObserver.php
+++ b/src/Observers/EcPoiObserver.php
@@ -37,7 +37,7 @@ class EcPoiObserver extends AbstractEcObserver
         // UserService::make()->assigUserAppIdIfNeeded(null, null, $ecPoi->app_id);
         $app = $ecPoi->app;
         if ($app) {
-            Artisan::queue('app:build-pois-geojson', [
+            Artisan::queue('wm:build-pois-geojson', [
                 'app_id' => $app->id,
             ]);
         }

--- a/src/Observers/EcPoiObserver.php
+++ b/src/Observers/EcPoiObserver.php
@@ -2,6 +2,7 @@
 
 namespace Wm\WmPackage\Observers;
 
+use Illuminate\Support\Facades\Artisan;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Wm\WmPackage\Models\EcPoi;
 use Wm\WmPackage\Services\Models\EcPoiService;
@@ -34,5 +35,11 @@ class EcPoiObserver extends AbstractEcObserver
         }
 
         // UserService::make()->assigUserAppIdIfNeeded(null, null, $ecPoi->app_id);
+        $app = $ecPoi->app;
+        if ($app) {
+            Artisan::queue('app:build-pois-geojson', [
+                'app_id' => $app->id,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
In the `EcPoiObserver`, added functionality to queue the Artisan command `app:build-pois-geojson` when an EcPoi instance's associated app exists. This ensures that the POIs GeoJSON is built efficiently in the background whenever there are changes to an EcPoi entity.
