### PR TITLE
feat(app): ✨ add filters tab with customizable filter options oc:6297

### DIFF
--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Config;
 use Kongulov\NovaTabTranslatable\NovaTabTranslatable;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\Code;
+use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Select;
@@ -44,6 +45,7 @@ class App extends Resource
                 Tab::make('release_data', $this->app_release_data_tab()),
                 Tab::make('pages', $this->pages_tab()),
                 Tab::make('acquisition_form', $this->acquisition_form_tab()),
+                Tab::make('filters', $this->filters_tab()),
             ]),
 
             // TODO: implement fields
@@ -63,7 +65,6 @@ class App extends Resource
 
     protected function webapp_tab(): array
     {
-
         return [
             Boolean::make(__('Show Auth at startup'), 'webapp_auth_show_at_startup')
                 ->default(false)
@@ -95,43 +96,43 @@ class App extends Resource
                 ->default(false)
                 ->hideFromIndex()
                 ->help(__('Enable POIs API layer for the app')),
-            
+
             Number::make(__('POI Min Radius'), 'poi_min_radius')
                 ->step(0.1)
                 ->default(0.5)
                 ->hideFromIndex()
                 ->help(__('Minimum radius for POI clustering')),
-            
+
             Number::make(__('POI Max Radius'), 'poi_max_radius')
                 ->step(0.1)
                 ->default(1.2)
                 ->hideFromIndex()
                 ->help(__('Maximum radius for POI clustering')),
-            
+
             Number::make(__('POI Icon Zoom'), 'poi_icon_zoom')
                 ->step(0.1)
                 ->default(16)
                 ->hideFromIndex()
                 ->help(__('Zoom level for POI icons')),
-            
+
             Number::make(__('POI Icon Radius'), 'poi_icon_radius')
                 ->step(0.1)
                 ->default(1)
                 ->hideFromIndex()
                 ->help(__('Radius for POI icons')),
-            
+
             Number::make(__('POI Min Zoom'), 'poi_min_zoom')
                 ->step(0.1)
                 ->default(5)
                 ->hideFromIndex()
                 ->help(__('Minimum zoom level to show POIs')),
-            
+
             Number::make(__('POI Label Min Zoom'), 'poi_label_min_zoom')
                 ->step(0.1)
                 ->default(10.5)
                 ->hideFromIndex()
                 ->help(__('Minimum zoom level to show POI labels')),
-            
+
             Select::make(__('POI Interaction'), 'poi_interaction')
                 ->options([
                     'popup' => __('Popup'),
@@ -232,6 +233,76 @@ class App extends Resource
                 ->rules('json')
                 ->default($this->getDefaultTrackForm())
                 ->help(__('This JSON structures the acquisition form for UGC Tracks. Knowledge of JSON format required.').view('wm-package::track-forms')->render()),
+        ];
+    }
+
+    protected function filters_tab(): array
+    {
+        return [
+            Heading::make(
+                <<<'HTML'
+                <h2><strong>FILTERS ACTIVATION</strong></h2>
+                HTML
+            )->asHtml(),
+            Boolean::make(__('Activity Filter'), 'filter_activity')
+                ->default(false)
+                ->hideFromIndex()
+                ->help(__('Activates the activity filter for tracks')),
+            Boolean::make(__('POI Type Filter'), 'filter_poi_type')
+                ->default(false)
+                ->hideFromIndex()
+                ->help(__('Activates the POI type filter for points of interest')),
+            Boolean::make(__('Track Duration Filter'), 'filter_track_duration')
+                ->default(false)
+                ->hideFromIndex()
+                ->help(__('Enables filtering of tracks by duration')),
+            Boolean::make(__('Track Distance Filter'), 'filter_track_distance')
+                ->default(false)
+                ->hideFromIndex()
+                ->help(__('Enables filtering of tracks by distance')),
+            Boolean::make(__('Track Difficulty Filter'), 'filter_track_difficulty')
+                ->default(false)
+                ->hideFromIndex()
+                ->help(__('Enables filtering of tracks by difficulty level')),
+            Heading::make(
+                <<<'HTML'
+                <h2><strong>FILTERS LABELS</strong></h2>
+                <br/>
+                <ul>
+                    <li><p><strong>Activity Filter Label</strong>: Text to be displayed for the Activity filter.</p></li>
+                    <li><p><strong>Theme Filter Label</strong>: Text to be displayed for the Theme filter.</p></li>
+                    <li><p><strong>Poi Type Filter Label</strong>: Text to be displayed for the Poi Type filter.</p></li>
+                    <li><p><strong>Duration Filter Label</strong>: Text to be displayed for the tracks duration filter.</p></li>
+                    <li><p><strong>Distance Filter Label</strong>: Text to be displayed for the tracks distance filter.</p></li>
+                </ul>
+                HTML
+            )->asHtml(),
+            NovaTabTranslatable::make([
+                Text::make('Activity Filter Label', 'filter_activity_label'),
+                Text::make('Theme Filter Label', 'filter_theme_label'),
+                Text::make('Poi Type Filter Label', 'filter_poi_type_label'),
+                Text::make('Duration Filter Label', 'filter_track_duration_label'),
+                Text::make('Distance Filter Label', 'filter_track_distance_label'),
+            ]),
+
+            Text::make('Activity Exclude Filter', 'filter_activity_exclude')
+                ->help(__('Insert the activities you want to exclude from the filter, separated by commas')),
+            Text::make('Theme Exclude Filter', 'filter_theme_exclude')
+                ->help(__('Insert the themes you want to exclude from the filter, separated by commas')),
+            Text::make('Poi Type Exclude Filter', 'filter_poi_type_exclude')
+                ->help(__('Insert the poi types you want to exclude from the filter, separated by commas')),
+            Number::make('Track Min Duration Filter', 'filter_track_duration_min')
+                ->help(__('Set the minimum duration of the duration filter')),
+            Number::make('Track Max Duration Filter', 'filter_track_duration_max')
+                ->help(__('Set the maximum duration of the duration filter')),
+            Number::make('Track Duration Steps Filter', 'filter_track_duration_steps')
+                ->help(__('Set the steps of the duration filter')),
+            Number::make('Track Min Distance Filter', 'filter_track_distance_min')
+                ->help(__('Set the minimum distance of the distance filter')),
+            Number::make('Track Max Distance Filter', 'filter_track_distance_max')
+                ->help(__('Set the maximum distance of the distance filter')),
+            Number::make('Track Distance Step Filter', 'filter_track_distance_steps')
+                ->help(__('Set the steps of the distance filter')),
         ];
     }
 


### PR DESCRIPTION
Added a new "filters" tab in the App resource to enable and customize various filtering options for tracks and points of interest (POIs). This includes activation toggles for activity, POI type, track duration, track distance, and track difficulty filters. Additionally, added translatable labels and exclusion options for each filter type, as well as settings for minimum, maximum, and step values for duration and distance filters.