### PR TITLE
feat(geometry): ✨ add conversion of MultiLineString to LineString OC:6418

### DIFF
--- a/src/Observers/EcTrackObserver.php
+++ b/src/Observers/EcTrackObserver.php
@@ -65,6 +65,10 @@ class EcTrackObserver extends AbstractEcObserver
 
             $ecTrack->setAttribute('properties', $properties);
         }
+
+        if (isset($ecTrack->geometry)) {
+            $ecTrack->geometry = $this->geometryComputationService->convertToLinestring($ecTrack->geometry);
+        }
     }
 
     /**

--- a/src/Services/GeometryComputationService.php
+++ b/src/Services/GeometryComputationService.php
@@ -46,6 +46,54 @@ class GeometryComputationService extends BaseService
         return DB::raw($finalSql, $bindings);
     }
 
+    /**
+     * Convert MultiLineString geometry to LineString if needed.
+     * If the geometry is already a LineString, returns it unchanged.
+     *
+     * @param  mixed  $geometry  The geometry to convert (WKT string or Expression)
+     * @return string|\Illuminate\Database\Query\Expression The converted geometry
+     */
+    public function convertToLinestring($geometry)
+    {
+        if (empty($geometry)) {
+            return $geometry;
+        }
+
+        try {
+            if ($geometry instanceof \Illuminate\Database\Query\Expression) {
+                $sqlValue = $geometry->getValue(app('db')->getQueryGrammar());
+
+                return DB::raw("ST_Force3D(ST_LineMerge($sqlValue))");
+            }
+
+            $sql = 'SELECT ST_GeometryType(?::geometry) As type, 
+                           ST_AsText(ST_Force3D(ST_LineMerge(?::geometry))) As linestring_wkt,
+                           ST_AsText(ST_Force3D(?::geometry)) As original_wkt';
+
+            $result = DB::select($sql, [$geometry, $geometry, $geometry]);
+
+            if (! empty($result) && isset($result[0]->type)) {
+                $geometryType = $result[0]->type;
+
+                if ($geometryType === 'ST_MultiLineString') {
+                    Log::info('Converting MultiLineString to LineString');
+
+                    return $result[0]->linestring_wkt;
+                }
+
+                return $result[0]->original_wkt;
+            }
+
+            return $geometry;
+        } catch (\Exception $e) {
+            Log::error('Error in convertToLinestring: '.$e->getMessage(), [
+                'geometry' => $geometry,
+            ]);
+
+            return $geometry;
+        }
+    }
+
     public function isGeometryLinestring(GeometryModel $model): bool
     {
         $geometryInput = $model->geometry;


### PR DESCRIPTION
- Implemented a method `convertToLinestring` in `GeometryComputationService` to handle the conversion of MultiLineString geometries to LineString.
- Updated the `EcTrackObserver` to utilize this method when setting geometry attributes, ensuring that any MultiLineString geometries are converted appropriately.
- The method checks if the geometry is an instance of `Expression` or a WKT string, applies necessary transformations, and logs conversions.
- Error handling is included to log any exceptions encountered during the conversion process.
