### PR TITLE
refactor(UgcPoiController): 🛠️ update UUID retrieval method oc:7478

### DIFF
--- a/src/Http/Controllers/Api/UgcPoiController.php
+++ b/src/Http/Controllers/Api/UgcPoiController.php
@@ -2,11 +2,10 @@
 
 namespace Wm\WmPackage\Http\Controllers\Api;
 
-use App\Models\UgcPoi;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Arr;
 use Wm\WmPackage\Http\Controllers\Api\Abstracts\UgcController;
+use Wm\WmPackage\Models\UgcPoi;
 
 class UgcPoiController extends UgcController
 {
@@ -15,7 +14,7 @@ class UgcPoiController extends UgcController
         if (! $request) {
             return new UgcPoi;
         }
-        $uuid = Arr::get($request->only('properties', []), 'uuid', null);
+        $uuid = $request->input('properties.uuid');
         if (! $uuid) {
             return new UgcPoi;
         }


### PR DESCRIPTION
- Replaced the use of `Arr::get` with a direct call to `$request->input` for fetching the UUID from the request properties, enhancing code clarity and reducing dependency on the Arr helper.
- Updated the UgcPoi model import to ensure proper namespacing.
