### PR TITLE
feat(app): ✨ add support for "My Routes" and "My Downloads" images OC:7480

### DIFF
--- a/database/factories/AppFactory.php
+++ b/database/factories/AppFactory.php
@@ -35,6 +35,8 @@ class AppFactory extends Factory
             'icon' => null,
             'splash' => null,
             'icon_small' => null,
+            'my_routes_image' => null,
+            'my_downloads_image' => null,
             'default_language' => 'it',
             'available_languages' => json_encode(['it', 'en']),
             'auth_show_at_startup' => $this->faker->boolean(),

--- a/database/migrations/create_apps_table.php.stub
+++ b/database/migrations/create_apps_table.php.stub
@@ -71,8 +71,6 @@ return new class extends Migration
             $table->string('icon')->nullable();
             $table->string('splash')->nullable();
             $table->string('icon_small')->nullable();
-            $table->string('my_routes_image')->nullable();
-            $table->string('my_downloads_image')->nullable();
             
             // ==================== HOME TAB ====================
             $table->text('welcome')->nullable();

--- a/database/migrations/create_apps_table.php.stub
+++ b/database/migrations/create_apps_table.php.stub
@@ -71,6 +71,8 @@ return new class extends Migration
             $table->string('icon')->nullable();
             $table->string('splash')->nullable();
             $table->string('icon_small')->nullable();
+            $table->string('my_routes_image')->nullable();
+            $table->string('my_downloads_image')->nullable();
             
             // ==================== HOME TAB ====================
             $table->text('welcome')->nullable();

--- a/database/migrations/zz_2026_03_30_120000_add_my_routes_image_and_my_downloads_image_to_apps_table.php.stub
+++ b/database/migrations/zz_2026_03_30_120000_add_my_routes_image_and_my_downloads_image_to_apps_table.php.stub
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('apps', function (Blueprint $table) {
+            $table->string('my_routes_image')->nullable()->after('icon_small');
+            $table->string('my_downloads_image')->nullable()->after('my_routes_image');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('apps', function (Blueprint $table) {
+            $table->dropColumn(['my_routes_image', 'my_downloads_image']);
+        });
+    }
+};

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -49,6 +49,8 @@
     "Horizon": "Horizon",
     "Icon": "Icon",
     "Icon small": "Icon small",
+    "My routes": "My routes",
+    "My downloads": "My downloads",
     "If enabled, the app will check for updates and show a popup when a new version is available.": "If enabled, the app will check for updates and show a popup when a new version is available.",
     "Image": "Image",
     "Insert the activities you want to exclude from the filter, separated by commas": "Insert the activities you want to exclude from the filter, separated by commas",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -73,6 +73,8 @@
     "Horizon": "Horizon",
     "Icon": "Icon",
     "Icon small": "Icon small",
+    "My routes": "My routes",
+    "My downloads": "My downloads",
     "If enabled, the app will check for updates and show a popup when a new version is available.": "If enabled, the app will check for updates and show a popup when a new version is available.",
     "Image": "Image",
     "Insert the activities you want to exclude from the filter, separated by commas": "Insert the activities you want to exclude from the filter, separated by commas",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -49,6 +49,8 @@
     "Horizon": "Horizon",
     "Icon": "Icona",
     "Icon small": "Icona piccola",
+    "My routes": "I miei percorsi",
+    "My downloads": "I miei download",
     "If enabled, the app will check for updates and show a popup when a new version is available.": "Se abilitato, l'app controllerà gli aggiornamenti e mostrerà un popup quando è disponibile una nuova versione.",
     "Image": "Immagine",
     "Insert the activities you want to exclude from the filter, separated by commas": "Inserisci le attività che vuoi escludere dal filtro, separate da virgole",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -73,6 +73,8 @@
     "Horizon": "Horizon",
     "Icon": "Icona",
     "Icon small": "Icona piccola",
+    "My routes": "I miei percorsi",
+    "My downloads": "I miei download",
     "If enabled, the app will check for updates and show a popup when a new version is available.": "Se abilitato, l'app controllerà gli aggiornamenti e mostrerà un popup quando è disponibile una nuova versione.",
     "Image": "Immagine",
     "Insert the activities you want to exclude from the filter, separated by commas": "Inserisci le attività che vuoi escludere dal filtro, separate da virgole",

--- a/routes/api.php
+++ b/routes/api.php
@@ -159,6 +159,8 @@ Route::name('api.')->group(function () {
             Route::get('/{app}/resources/splash.png', [AppController::class, 'splash'])->name('splash');
             Route::get('/{app}/resources/icon_small.png', [AppController::class, 'iconSmall'])->name('icon_small');
             Route::get('/{app}/resources/feature_image.png', [AppController::class, 'featureImage'])->name('feature_image');
+            Route::get('/{app}/resources/my_routes_image.png', [AppController::class, 'myRoutes'])->name('my_routes_image');
+            Route::get('/{app}/resources/my_downloads_image.png', [AppController::class, 'myDownloads'])->name('my_downloads_image');
 
             Route::get('/{app}/geojson/ec_poi_{poi}.geojson', [AppElbrusEditorialContentController::class, 'getPoiGeojson'])->name('geojson.poi');
             Route::get('/{app}/geojson/ec_track_{track}.geojson', [AppElbrusEditorialContentController::class, 'getTrackGeojson'])->name('geojson.track');
@@ -181,6 +183,8 @@ Route::name('api.')->group(function () {
             Route::get('/{app}/resources/splash.png', [AppController::class, 'splash'])->name('splash');
             Route::get('/{app}/resources/icon_small.png', [AppController::class, 'iconSmall'])->name('icon_small');
             Route::get('/{app}/resources/feature_image.png', [AppController::class, 'featureImage'])->name('feature_image');
+            Route::get('/{app}/resources/my_routes_image.png', [AppController::class, 'myRoutes'])->name('my_routes_image');
+            Route::get('/{app}/resources/my_downloads_image.png', [AppController::class, 'myDownloads'])->name('my_downloads_image');
             Route::get('/{app}/resources/icon_notify.png', [AppController::class, 'iconNotify'])->name('icon_notify');
             Route::get('/{app}/resources/logo_homepage.svg', [AppController::class, 'logoHomepage'])->name('logo_homepage');
         });
@@ -222,6 +226,8 @@ Route::name('api.')->group(function () {
                 Route::get('/{id}/resources/splash.png', [AppController::class, 'splash'])->name('splash');
                 Route::get('/{id}/resources/icon_small.png', [AppController::class, 'iconSmall'])->name('icon_small');
                 Route::get('/{id}/resources/feature_image.png', [AppController::class, 'featureImage'])->name('feature_image');
+                Route::get('/{id}/resources/my_routes_image.png', [AppController::class, 'myRoutes'])->name('my_routes_image');
+                Route::get('/{id}/resources/my_downloads_image.png', [AppController::class, 'myDownloads'])->name('my_downloads_image');
                 Route::get('/{id}/resources/icon_notify.png', [AppController::class, 'iconNotify'])->name('icon_notify');
                 Route::get('/{id}/resources/logo_homepage.svg', [AppController::class, 'logoHomepage'])->name('logo_homepage');
             });

--- a/src/Http/Controllers/Api/AppController.php
+++ b/src/Http/Controllers/Api/AppController.php
@@ -50,6 +50,16 @@ class AppController extends Controller
         return $this->getOrDownloadIcon($app, 'logo_homepage');
     }
 
+    public function myRoutes(App $app)
+    {
+        return $this->getOrDownloadIcon($app, 'my_routes_image');
+    }
+
+    public function myDownloads(App $app)
+    {
+        return $this->getOrDownloadIcon($app, 'my_downloads_image');
+    }
+
     protected function getOrDownloadIcon(App $app, $type = 'icon')
     {
         if (! isset($app->$type)) {

--- a/src/Models/App.php
+++ b/src/Models/App.php
@@ -550,6 +550,8 @@ class App extends Model implements HasMedia
         $this->addMediaCollection('icon');
         $this->addMediaCollection('icon_small');
         $this->addMediaCollection('splash');
+        $this->addMediaCollection('my_routes_image');
+        $this->addMediaCollection('my_downloads_image');
     }
 
     // Le funzioni custom per config_home sono state spostate nel resolver layerBoxResolver

--- a/src/Models/App.php
+++ b/src/Models/App.php
@@ -570,6 +570,8 @@ class App extends Model implements HasMedia
         $this->addMediaCollection('icon');
         $this->addMediaCollection('icon_small');
         $this->addMediaCollection('splash');
+        $this->addMediaCollection('my_routes_image');
+        $this->addMediaCollection('my_downloads_image');
     }
 
     // Le funzioni custom per config_home sono state spostate nel resolver layerBoxResolver

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -356,6 +356,10 @@ class App extends Resource
                 // ->rules('image', 'mimes:png', 'dimensions:width=512,height=512')
                 ->help(__('Required size is :widthx:heightpx', ['width' => 512, 'height' => 512]))
                 ->hideFromIndex(),
+            Images::make(__('My routes'), 'my_routes_image')
+                ->hideFromIndex(),
+            Images::make(__('My downloads'), 'my_downloads_image')
+                ->hideFromIndex(),
             Boolean::make(__('Force to Release Update'), 'properties->force_to_release_update')
                 ->default(false)
                 ->hideFromIndex()

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -648,6 +648,10 @@ class App extends Resource
                 // ->rules('image', 'mimes:png', 'dimensions:width=512,height=512')
                 ->help(__('Required size is :widthx:heightpx', ['width' => 512, 'height' => 512]))
                 ->hideFromIndex(),
+            Images::make(__('My routes'), 'my_routes_image')
+                ->hideFromIndex(),
+            Images::make(__('My downloads'), 'my_downloads_image')
+                ->hideFromIndex(),
             Boolean::make(__('Force to Release Update'), 'properties->force_to_release_update')
                 ->default(false)
                 ->hideFromIndex()

--- a/src/Services/Models/App/AppConfigService.php
+++ b/src/Services/Models/App/AppConfigService.php
@@ -108,6 +108,13 @@ class AppConfigService extends AppBaseService
             $data['APP']['iosStore'] = $this->app->ios_store_link;
         }
 
+        if ($this->app->my_routes_image) {
+            $data['APP']['myRoutesImageUrl'] = url('/api/app/webmapp/'.$this->app->id.'/resources/my_routes_image.png');
+        }
+        if ($this->app->my_downloads_image) {
+            $data['APP']['myDownloadsImageUrl'] = url('/api/app/webmapp/'.$this->app->id.'/resources/my_downloads_image.png');
+        }
+
         if (isset($properties['force_to_release_update']) && $properties['force_to_release_update']) {
             $data['APP']['forceToReleaseUpdate'] = true;
         }


### PR DESCRIPTION
- Updated AppFactory to include 'my_routes_image' and 'my_downloads_image' fields as nullable.
- Modified database migration to add new columns for 'my_routes_image' and 'my_downloads_image'.
- Enhanced language files with translations for "My Routes" and "My Downloads" in English and Italian.
- Expanded API routes to handle requests for "my_routes_image" and "my_downloads_image".
- Added new methods in AppController to serve "My Routes" and "My Downloads" images.
- Modified App model to include media collections for the new image types.
- Updated Nova resource to manage "My Routes" and "My Downloads" images.
- Enhanced AppConfigService to provide URLs for the new images if available.
