### PR TITLE
feat(schema): ✨ update description field type to Tiptap editor OC:7486

### DIFF
--- a/config/wm-ec-poi-schema.php
+++ b/config/wm-ec-poi-schema.php
@@ -9,7 +9,7 @@ return [
         'fields' => [
             [
                 'name' => 'description',
-                'type' => 'textarea',
+                'type' => 'tiptap',
                 'required' => false,
                 'translatable' => true,
                 'label' => [

--- a/config/wm-ec-track-schema.php
+++ b/config/wm-ec-track-schema.php
@@ -9,7 +9,7 @@ return [
         'fields' => [
             [
                 'name' => 'description',
-                'type' => 'textarea',
+                'type' => 'tiptap',
                 'required' => false,
                 'translatable' => true,
                 'label' => [

--- a/config/wm-layer-schema.php
+++ b/config/wm-layer-schema.php
@@ -10,7 +10,7 @@ return [
 
             [
                 'name' => 'description',
-                'type' => 'textarea',
+                'type' => 'tiptap',
                 'required' => false,
                 'translatable' => true,
                 'label' => [

--- a/src/Nova/Fields/PropertiesPanel.php
+++ b/src/Nova/Fields/PropertiesPanel.php
@@ -20,6 +20,7 @@ use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Textarea;
 use Laravel\Nova\Panel;
+use Marshmallow\Tiptap\Tiptap;
 use Wm\WmPackage\Models\UgcPoi;
 use Wm\WmPackage\Models\User;
 
@@ -50,6 +51,30 @@ class PropertiesPanel extends Panel
 
         parent::__construct($name, []);
     }
+
+    protected function tiptapButtons(): array
+    {
+        return [
+            'heading',
+            '|',
+            'bold',
+            'italic',
+            'underline',
+            '|',
+            'bulletList',
+            'orderedList',
+            '|',
+            'link',
+            'image',
+            '|',
+            'textAlign',
+            '|',
+            'horizontalRule',
+            '|',
+            'editHtml',
+        ];
+    }
+
 
     /**
      * Determine if fields should be editable based on editable parameter
@@ -432,6 +457,17 @@ class PropertiesPanel extends Panel
                         ->displayUsing(function ($value) {
                             return $value;
                         });
+                }
+                break;
+
+            case 'tiptap':
+                $tiptap = Tiptap::make($label, $jsonPath)
+                    ->buttons($this->tiptapButtons())
+                    ->headingLevels([2, 3, 4]);
+                if ($isTranslatable) {
+                    $field = NovaTabTranslatable::make([$tiptap]);
+                } else {
+                    $field = $tiptap;
                 }
                 break;
 

--- a/tests/Unit/EcDescriptionTiptapTest.php
+++ b/tests/Unit/EcDescriptionTiptapTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Wm\WmPackage\Tests\Unit;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use ReflectionMethod;
+use Wm\WmPackage\Models\App as AppModel;
+use Wm\WmPackage\Models\EcPoi;
+use Wm\WmPackage\Models\EcTrack;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Nova\App as NovaAppResource;
+use Wm\WmPackage\Nova\Fields\PropertiesPanel;
+use Wm\WmPackage\Tests\TestCase;
+
+class EcDescriptionTiptapTest extends TestCase
+{
+    use DatabaseTransactions;
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'wm-package.shard_name' => 'test_shard',
+            'wm-package.ec_track_model' => EcTrack::class,
+            'cache.stores.redis.driver' => 'array',
+        ]);
+
+        Storage::fake('wmfe');
+        Storage::fake('conf');
+        Storage::fake('pois');
+
+        Bus::fake();
+        Queue::fake();
+    }
+
+    public function test_wm_schemas_expose_description_as_translatable_tiptap_for_track_poi_and_layer(): void
+    {
+        $trackDesc = collect(config('wm-ec-track-schema.properties.fields'))->firstWhere('name', 'description');
+        $poiDesc = collect(config('wm-ec-poi-schema.properties.fields'))->firstWhere('name', 'description');
+        $layerDesc = collect(config('wm-layer-schema.properties.fields'))->firstWhere('name', 'description');
+
+        $this->assertSame('tiptap', $trackDesc['type']);
+        $this->assertTrue($trackDesc['translatable']);
+        $this->assertSame('tiptap', $poiDesc['type']);
+        $this->assertTrue($poiDesc['translatable']);
+        $this->assertSame('tiptap', $layerDesc['type']);
+        $this->assertTrue($layerDesc['translatable']);
+    }
+
+    public function test_nova_app_resource_and_properties_panel_use_the_same_tiptap_toolbar_buttons(): void
+    {
+        $appModel = AppModel::factory()->createQuietly();
+        $novaApp = new NovaAppResource($appModel);
+
+        $tiptapOnApp = new ReflectionMethod(NovaAppResource::class, 'tiptapButtons');
+        $tiptapOnApp->setAccessible(true);
+        $fromApp = $tiptapOnApp->invoke($novaApp);
+
+        $panelProbe = new class extends PropertiesPanel
+        {
+            public function toolbarForTest(): array
+            {
+                return $this->tiptapButtons();
+            }
+        };
+        $fromPanel = $panelProbe->toolbarForTest();
+
+        $this->assertSame($fromPanel, $fromApp);
+        foreach (['heading', 'bold', 'link', 'editHtml'] as $item) {
+            $this->assertContains($item, $fromApp);
+        }
+    }
+
+    public function test_ec_track_round_trips_plain_string_in_properties_description_translation(): void
+    {
+        $app = AppModel::factory()->createQuietly();
+        $plain = 'Descrizione semplice senza tag HTML';
+
+        $track = EcTrack::factory()->createQuietly([
+            'app_id' => $app->id,
+        ]);
+        $track->setTranslation('properties->description', 'it', $plain);
+        $track->save();
+        $track->refresh();
+
+        $this->assertSame($plain, $track->getTranslation('properties->description', 'it'));
+    }
+
+    public function test_ec_poi_round_trips_plain_string_in_properties_description_translation(): void
+    {
+        $app = AppModel::factory()->createQuietly();
+        $plain = 'Testo POI semplice';
+
+        $geojson = json_encode([
+            'type' => 'Point',
+            'coordinates' => [9.0, 40.0, 10.0],
+        ]);
+
+        $poi = EcPoi::query()->createQuietly([
+            'app_id' => $app->id,
+            'name' => ['it' => 'POI test', 'en' => 'POI test'],
+            'geometry' => DB::raw("ST_GeomFromGeoJSON('{$geojson}')"),
+            'properties' => [],
+        ]);
+        $poi->setTranslation('properties->description', 'it', $plain);
+        $poi->save();
+        $poi->refresh();
+
+        $this->assertSame($plain, $poi->getTranslation('properties->description', 'it'));
+    }
+
+    public function test_layer_round_trips_plain_string_in_properties_description_translation(): void
+    {
+        $app = AppModel::factory()->createQuietly();
+        $plain = 'Descrizione layer come stringa semplice';
+
+        $geojson = json_encode([
+            'type' => 'Polygon',
+            'coordinates' => [[
+                [10.0, 40.0],
+                [10.1, 40.0],
+                [10.1, 40.1],
+                [10.0, 40.1],
+                [10.0, 40.0],
+            ]],
+        ]);
+
+        $layer = Layer::query()->createQuietly([
+            'app_id' => $app->id,
+            'name' => ['it' => 'Layer test', 'en' => 'Layer test'],
+            'geometry' => DB::raw("ST_GeomFromGeoJSON('{$geojson}')"),
+            'properties' => [],
+        ]);
+        $layer->setTranslation('properties->description', 'it', $plain);
+        $layer->save();
+        $layer->refresh();
+
+        $this->assertSame($plain, $layer->getTranslation('properties->description', 'it'));
+    }
+}
+


### PR DESCRIPTION
- Changed the 'description' field type from 'textarea' to 'tiptap' in the POI, track, and layer schemas to enhance text editing capabilities.
- Updated the PropertiesPanel to include the Tiptap editor with a customized set of buttons for a richer text editing experience.
- Added `use Marshmallow\Tiptap\Tiptap` to the PropertiesPanel to support the new editor functionality.
- Implemented a method `tiptapButtons()` to define the available formatting options in the Tiptap editor.
- Ensured compatibility with translatable fields for the Tiptap editor in the PropertiesPanel.
