### PR TITLE
refactor(labels): ♻️ update singular labels for Ec and Ugc resources OC:7503

### DIFF
--- a/src/Nova/EcPoi.php
+++ b/src/Nova/EcPoi.php
@@ -30,7 +30,7 @@ class EcPoi extends AbstractEcResource
 
     public static function singularLabel(): string
     {
-        return __('Poi');
+        return __('EC Poi');
     }
 
     public static $model = \Wm\WmPackage\Models\EcPoi::class;

--- a/src/Nova/EcTrack.php
+++ b/src/Nova/EcTrack.php
@@ -32,7 +32,7 @@ class EcTrack extends AbstractEcResource
 
     public static function singularLabel(): string
     {
-        return __('Track');
+        return __('EC Track');
     }
 
     public static $model = \Wm\WmPackage\Models\EcTrack::class;

--- a/src/Nova/Media.php
+++ b/src/Nova/Media.php
@@ -35,11 +35,11 @@ class Media extends AbstractGeometryResource
             MorphTo::make(__('Model'), 'model')
                 ->types([
                     App::class,
+                    EcPoi::class,
+                    EcTrack::class,
                     Layer::class,
                     UgcPoi::class,
                     UgcTrack::class,
-                    EcPoi::class,
-                    EcTrack::class,
                 ])
                 ->searchable(),
             Text::make('UUID', 'uuid'),

--- a/src/Nova/Media.php
+++ b/src/Nova/Media.php
@@ -34,6 +34,8 @@ class Media extends AbstractGeometryResource
             ...$this->fieldsFromTrait($request),
             MorphTo::make(__('Model'), 'model')
                 ->types([
+                    App::class,
+                    Layer::class,
                     UgcPoi::class,
                     UgcTrack::class,
                     EcPoi::class,

--- a/src/Nova/UgcPoi.php
+++ b/src/Nova/UgcPoi.php
@@ -20,7 +20,7 @@ class UgcPoi extends AbstractUgcResource
 
     public static function singularLabel(): string
     {
-        return __('Poi');
+        return __('UGC Poi');
     }
 
     public function actions(NovaRequest $request): array

--- a/src/Nova/UgcTrack.php
+++ b/src/Nova/UgcTrack.php
@@ -17,6 +17,6 @@ class UgcTrack extends AbstractUgcResource
 
     public static function singularLabel(): string
     {
-        return __('Track');
+        return __('UGC Track');
     }
 }


### PR DESCRIPTION
- Changed singular labels for EcPoi and EcTrack to "EC Poi" and "EC Track" to enhance clarity and consistency.
- Updated singular labels for UgcPoi and UgcTrack to "UGC Poi" and "UGC Track" for better distinction between EC and UGC resources.
- Added `App::class` and `Layer::class` to the MorphTo types in the Media resource to extend its functionality and support more model types.
