### PR TITLE
feat(nova): enhance multilingual title handling OC:7505

### DIFF
--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -697,31 +697,49 @@ class App extends Resource
 
     protected function title_layout(): array
     {
-        return [
-            Text::make('Titolo', 'title')->rules('required'),
-        ];
+        return $this->config_home_title_layout();
     }
 
     protected function slug_layout(): array
     {
-        return [
-            Text::make('Title', 'title'),
+        return array_merge($this->config_home_title_layout(), [
             Text::make('Slug', 'slug')
                 ->rules('required')
                 ->resolveUsing(function ($value) {
                     return $value ?: 'project';
                 }),
             Text::make('Image url', 'image_url'), // TODO: fare in modo di usare Media caricando un immagine e restituendo l'url
-        ];
+        ]);
     }
 
     protected function external_url_layout(): array
     {
-        return [
-            Text::make('Title', 'title'),
+        return array_merge($this->config_home_title_layout(), [
             Text::make('Url', 'url')->rules('required'),
             Text::make('Image url', 'image_url'), // TODO: fare in modo di usare Media caricando un immagine e restituendo l'url
-        ];
+        ]);
+    }
+
+    protected function config_home_title_layout(): array
+    {
+        $languages = Config::get('wm-app-languages.languages', []);
+        $fields = [];
+        $requiredLocales = $this->config_home_required_locales();
+
+        foreach ($languages as $locale => $name) {
+            $field = Text::make($name, 'title_'.$locale);
+            if (in_array($locale, $requiredLocales, true)) {
+                $field->rules('required');
+            }
+            $fields[] = $field;
+        }
+
+        return $fields;
+    }
+
+    protected function config_home_required_locales(): array
+    {
+        return ['it'];
     }
 
     protected function base_layout(): array

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -31,9 +31,12 @@ use Wm\WmPackage\Nova\Actions\ReindexAppScoutAction;
 use Wm\WmPackage\Nova\Fields\StoreVersionField;
 use Wm\WmPackage\Nova\Flexible\Resolvers\ConfigHomeResolver;
 use Wm\WmPackage\Nova\Flexible\Resolvers\ConfigOverlaysResolver;
+use Wm\WmPackage\Nova\Traits\HasFlexibleTranslatableFields;
 
 class App extends Resource
 {
+    use HasFlexibleTranslatableFields;
+
     public static $model = \Wm\WmPackage\Models\App::class;
 
     protected function tiptapButtons(): array
@@ -173,14 +176,7 @@ class App extends Resource
 
     protected function overlays_title_layout(): array
     {
-        $languages = Config::get('wm-app-languages.languages', []);
-        $fields = [];
-
-        foreach ($languages as $locale => $name) {
-            $fields[] = Text::make($name, 'label_'.$locale);
-        }
-
-        return $fields;
+        return $this->translatableFields('Label', 'label');
     }
 
     protected function feature_collection_layout(): array
@@ -584,7 +580,7 @@ class App extends Resource
                         ->orderBy('id')
                         ->get()
                         ->mapWithKeys(function ($layer) {
-                            $title = $layer->getStringName() ?: ('Layer #'.$layer->id);
+                            $title = $layer->getStringName() ?: ('Layer #' . $layer->id);
 
                             return [$layer->id => $title];
                         })
@@ -722,24 +718,7 @@ class App extends Resource
 
     protected function config_home_title_layout(): array
     {
-        $languages = Config::get('wm-app-languages.languages', []);
-        $fields = [];
-        $requiredLocales = $this->config_home_required_locales();
-
-        foreach ($languages as $locale => $name) {
-            $field = Text::make($name, 'title_'.$locale);
-            if (in_array($locale, $requiredLocales, true)) {
-                $field->rules('required');
-            }
-            $fields[] = $field;
-        }
-
-        return $fields;
-    }
-
-    protected function config_home_required_locales(): array
-    {
-        return ['it'];
+        return $this->translatableFields('Title', 'title', required: true);
     }
 
     protected function base_layout(): array

--- a/src/Nova/Flexible/Resolvers/ConfigHomeResolver.php
+++ b/src/Nova/Flexible/Resolvers/ConfigHomeResolver.php
@@ -38,22 +38,7 @@ class ConfigHomeResolver implements ResolverInterface
                 $layout = $layouts->find($item['box_type']);
 
                 if ($layout) {
-                    $attributes = [];
-                    foreach ($item as $key => $val) {
-                        if ($key === 'box_type') {
-                            continue;
-                        }
-
-                        // Expand title array into title_{locale} fields
-                        if ($key === 'title' && is_array($val)) {
-                            foreach ($val as $locale => $translation) {
-                                $attributes['title_'.$locale] = $translation;
-                            }
-                        } else {
-                            $attributes[$key] = $val;
-                        }
-                    }
-
+                    $attributes = array_filter($item, fn($key) => $key !== 'box_type', ARRAY_FILTER_USE_KEY);
                     $result->push($layout->duplicateAndHydrate(uniqid('', true), $attributes));
                 }
             }
@@ -66,7 +51,7 @@ class ConfigHomeResolver implements ResolverInterface
      * Save the Flexible field's content somewhere the get method will be able to access it.
      *
      * @param  mixed  $resource
-     * @param  string  $attribute  Attribute name set for a Flexible field.
+     * @param  string  $attribute
      * @param  Collection<int, Layout>  $groups
      * @return mixed
      */
@@ -81,48 +66,20 @@ class ConfigHomeResolver implements ResolverInterface
         $homeData = [];
 
         foreach ($groups as $layout) {
-            $homeElement = [
-                'box_type' => $layout->name(),
-            ];
+            $homeElement = ['box_type' => $layout->name()];
 
-            $titleData = [];
-
-            // Merge all attributes
             foreach ($layout->getAttributes() as $key => $val) {
-                // Ensure 'layer' is always an integer
                 if ($key === 'layer' && $val) {
                     $homeElement[$key] = (int) $val;
-                } elseif (str_starts_with($key, 'title_')) {
-                    $locale = substr($key, 6);
-                    if (! is_null($val) && $val !== '') {
-                        $titleData[$locale] = $val;
-                    }
-                } else {
-                    // Do not write empty fields to JSON: avoids keys like "x": null or "x": ""
-                    if (! is_null($val) && $val !== '') {
-                        $homeElement[$key] = $val;
-                    }
+                } elseif (! is_null($val) && $val !== '') {
+                    $homeElement[$key] = $val;
                 }
             }
 
-            if (! empty($titleData)) {
-                $homeElement['title'] = $titleData;
-            }
-
-            // If it's a Layer layout, automatically add the layer title
             if ($layout->name() === 'layer' && isset($homeElement['layer'])) {
-                $layerId = $homeElement['layer'];
-                $layer = Layer::find($layerId);
-
+                $layer = Layer::find($homeElement['layer']);
                 if ($layer) {
-                    $title = $layer->getStringName();
-
-                    if (empty($title)) {
-                        $title = 'Layer #'.$layer->id;
-                    }
-
-                    // Aggiungiamo il titolo del layer come 'name'
-                    $homeElement['title'] = $title;
+                    $homeElement['title'] = $layer->getStringName() ?: 'Layer #'.$layer->id;
                 }
             }
 

--- a/src/Nova/Flexible/Resolvers/ConfigHomeResolver.php
+++ b/src/Nova/Flexible/Resolvers/ConfigHomeResolver.php
@@ -40,7 +40,16 @@ class ConfigHomeResolver implements ResolverInterface
                 if ($layout) {
                     $attributes = [];
                     foreach ($item as $key => $val) {
-                        if ($key !== 'box_type') {
+                        if ($key === 'box_type') {
+                            continue;
+                        }
+
+                        // Expand title array into title_{locale} fields
+                        if ($key === 'title' && is_array($val)) {
+                            foreach ($val as $locale => $translation) {
+                                $attributes['title_'.$locale] = $translation;
+                            }
+                        } else {
                             $attributes[$key] = $val;
                         }
                     }
@@ -76,17 +85,31 @@ class ConfigHomeResolver implements ResolverInterface
                 'box_type' => $layout->name(),
             ];
 
+            $titleData = [];
+
             // Merge all attributes
             foreach ($layout->getAttributes() as $key => $val) {
-                // Assicuriamoci che 'layer' sia sempre un numero intero
+                // Ensure 'layer' is always an integer
                 if ($key === 'layer' && $val) {
                     $homeElement[$key] = (int) $val;
+                } elseif (str_starts_with($key, 'title_')) {
+                    $locale = substr($key, 6);
+                    if (! is_null($val) && $val !== '') {
+                        $titleData[$locale] = $val;
+                    }
                 } else {
-                    $homeElement[$key] = $val;
+                    // Do not write empty fields to JSON: avoids keys like "x": null or "x": ""
+                    if (! is_null($val) && $val !== '') {
+                        $homeElement[$key] = $val;
+                    }
                 }
             }
 
-            // Se è un layout di tipo Layer, aggiungiamo automaticamente il titolo del layer
+            if (! empty($titleData)) {
+                $homeElement['title'] = $titleData;
+            }
+
+            // If it's a Layer layout, automatically add the layer title
             if ($layout->name() === 'layer' && isset($homeElement['layer'])) {
                 $layerId = $homeElement['layer'];
                 $layer = Layer::find($layerId);

--- a/src/Nova/Flexible/Resolvers/ConfigOverlaysResolver.php
+++ b/src/Nova/Flexible/Resolvers/ConfigOverlaysResolver.php
@@ -38,21 +38,7 @@ class ConfigOverlaysResolver implements ResolverInterface
                 $layout = $layouts->find($item['box_type']);
 
                 if ($layout) {
-                    $attributes = [];
-                    foreach ($item as $key => $val) {
-                        if ($key === 'box_type') {
-                            continue;
-                        }
-                        // Expand label array into label_{locale} fields
-                        if ($key === 'label' && is_array($val)) {
-                            foreach ($val as $locale => $translation) {
-                                $attributes['label_'.$locale] = $translation;
-                            }
-                        } else {
-                            $attributes[$key] = $val;
-                        }
-                    }
-
+                    $attributes = array_filter($item, fn($key) => $key !== 'box_type', ARRAY_FILTER_USE_KEY);
                     $result->push($layout->duplicateAndHydrate(uniqid('', true), $attributes));
                 }
             }
@@ -80,24 +66,14 @@ class ConfigOverlaysResolver implements ResolverInterface
         $overlaysData = [];
 
         foreach ($groups as $layout) {
-            $element = [
-                'box_type' => $layout->name(),
-            ];
+            $element = ['box_type' => $layout->name()];
 
-            $labelData = [];
             foreach ($layout->getAttributes() as $key => $val) {
                 if ($key === 'feature_collection' && $val) {
                     $element[$key] = (int) $val;
-                } elseif (str_starts_with($key, 'label_') && $val) {
-                    $locale = substr($key, 6);
-                    $labelData[$locale] = $val;
-                } else {
+                } elseif (! is_null($val) && $val !== '') {
                     $element[$key] = $val;
                 }
-            }
-
-            if (! empty($labelData)) {
-                $element['label'] = $labelData;
             }
 
             if ($layout->name() === 'feature_collection' && isset($element['feature_collection'])) {

--- a/src/Nova/Traits/HasFlexibleTranslatableFields.php
+++ b/src/Nova/Traits/HasFlexibleTranslatableFields.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Wm\WmPackage\Nova\Traits;
+
+use Illuminate\Support\Facades\Config;
+use Laravel\Nova\Fields\Text;
+
+trait HasFlexibleTranslatableFields
+{
+    protected function translatableFields(string $label, string $attribute, bool $required = false): array
+    {
+        $languages = Config::get('wm-app-languages.languages', []);
+        $fields = [];
+
+        foreach ($languages as $locale => $name) {
+            $field = Text::make("{$name}", "{$attribute}->{$locale}");
+            if ($required && $locale === 'it') {
+                $field->rules('required');
+            }
+            $fields[] = $field;
+        }
+
+        return $fields;
+    }
+}


### PR DESCRIPTION
Refactor title, slug, and external URL layouts to support multiple languages dynamically. Introduce a new method to generate multilingual title fields based on configuration. Update the resolver to expand title arrays into locale-specific fields, optimizing data storage.