### PR TITLE
feat(nova): ✨ add global CSS overrides for Nova UI oc:7504

### DIFF
--- a/resources/css/nova.css
+++ b/resources/css/nova.css
@@ -1,0 +1,12 @@
+/**
+ * Global Nova UI overrides shared across shards.
+ *
+ * Keep selectors tight and scoped to Nova UI to avoid leaking into non-Nova pages.
+ */
+
+@media (min-width: 768px) {
+    .flex.md\:hidden {
+        display: none;
+    }
+}
+

--- a/src/WmPackageServiceProvider.php
+++ b/src/WmPackageServiceProvider.php
@@ -83,6 +83,7 @@ class WmPackageServiceProvider extends PackageServiceProvider
         // Register Nova CSS assets
         Nova::serving(function () {
             Nova::style('wm-flexible-field', __DIR__.'/../resources/css/flexible-field.css');
+            Nova::style('wm-nova-overrides', __DIR__.'/../resources/css/nova.css');
             $this->addWmpackageToolsMenuItem();
         });
 


### PR DESCRIPTION
- Introduced a new CSS file `nova.css` containing global UI overrides for the Nova interface.
- Added media query to hide specific elements on medium and larger screens, ensuring a cleaner UI experience.
- Registered the new CSS file in the `WmPackageServiceProvider` to apply the styles across the application.
