### PR TITLE
feat(validation): ✨ add zoom level validation rules OC:7548

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -84,6 +84,8 @@
     "Play Store link (android)": "Play Store link (android)",
     "Poi": "Poi",
     "Popup": "Popup",
+    "Max Zoom must be greater than or equal to Min Zoom.": "Max Zoom must be greater than or equal to Min Zoom.",
+    "Min Zoom must be less than or equal to Max Zoom.": "Min Zoom must be less than or equal to Max Zoom.",
     "Process Track Data": "Process Track Data",
     "Primary Color": "Primary Color",
     "Primary color for the WordPress theme (e.g. buttons, links)": "Primary color for the WordPress theme (e.g. buttons, links)",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -84,6 +84,8 @@
     "Play Store link (android)": "Link Play Store (android)",
     "Poi": "POI",
     "Popup": "Popup",
+    "Max Zoom must be greater than or equal to Min Zoom.": "Lo zoom massimo deve essere maggiore o uguale allo zoom minimo.",
+    "Min Zoom must be less than or equal to Max Zoom.": "Lo zoom minimo deve essere minore o uguale allo zoom massimo.",
     "Process Track Data": "Process Track Data",
     "Primary Color": "Colore Primario",
     "Primary color for the WordPress theme (e.g. buttons, links)": "Colore primario per il tema WordPress (es. pulsanti, link)",

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -667,10 +667,34 @@ class App extends Resource
                 ->help(__('The default zoom level when the map is first loaded.')),
             Number::make(__('Max Zoom'), 'map_max_zoom')
                 ->min(1)->max(20)->default(16)
+                ->rules([
+                    function (string $attribute, mixed $value, \Closure $fail) {
+                        $min = request()->input('map_min_zoom');
+                        if ($min === null || $min === '') {
+                            return;
+                        }
+
+                        if ((float) $value < (float) $min) {
+                            $fail(__('Max Zoom must be greater than or equal to Min Zoom.'));
+                        }
+                    },
+                ])
                 ->hideFromIndex()
                 ->help(__('Maximum zoom level for the map')),
             Number::make(__('Min Zoom'), 'map_min_zoom')
                 ->min(1)->max(20)->default(12)
+                ->rules([
+                    function (string $attribute, mixed $value, \Closure $fail) {
+                        $max = request()->input('map_max_zoom');
+                        if ($max === null || $max === '') {
+                            return;
+                        }
+
+                        if ((float) $value > (float) $max) {
+                            $fail(__('Min Zoom must be less than or equal to Max Zoom.'));
+                        }
+                    },
+                ])
                 ->hideFromIndex()
                 ->help(__('Minimum zoom level for the map')),
             Number::make(__('Max Stroke width'), 'map_max_stroke_width')


### PR DESCRIPTION
- Implement validation rules to ensure "Max Zoom" is greater than or equal to "Min Zoom" in the map configuration
- Add corresponding error messages in English and Italian localization files
- Enhance user input validation to improve map configuration reliability and prevent errors related to zoom level settings
