### PR TITLE
feat(app): ✨ add theme tab to app resource OC:7590

### DIFF
--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -262,16 +262,16 @@ class App extends Resource
     protected function theme_tab(): array
     {
         return [
-            Text::make(__('Font Family Header'), 'font_family_header')
+            Text::make(__('Font Family Header'), 'properties->theme->font_family_header')
                 ->hideFromIndex()
                 ->help(__('Font family used for headings in the app theme')),
-            Text::make(__('Font Family Content'), 'font_family_content')
+            Text::make(__('Font Family Content'), 'properties->theme->font_family_content')
                 ->hideFromIndex()
                 ->help(__('Font family used for body content in the app theme')),
-            Color::make(__('Primary color'), 'primary_color')
+            Color::make(__('Primary color'), 'properties->theme->primary_color')
                 ->hideFromIndex()
                 ->help(__('Primary color for the app theme (e.g. buttons, links)')),
-            Color::make(__('Default feature color'), 'default_feature_color')
+            Color::make(__('Default feature color'), 'properties->theme->default_feature_color')
                 ->hideFromIndex()
                 ->help(__('Default color used for map features when no specific style is set')),
         ];

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -262,16 +262,16 @@ class App extends Resource
     protected function theme_tab(): array
     {
         return [
-            Text::make(__('Font Family Header'), 'properties->theme->fontFamilyHeader')
+            Text::make(__('Font Family Header'), 'font_family_header')
                 ->hideFromIndex()
                 ->help(__('Font family used for headings in the app theme')),
-            Text::make(__('Font Family Content'), 'properties->theme->fontFamilyContent')
+            Text::make(__('Font Family Content'), 'font_family_content')
                 ->hideFromIndex()
                 ->help(__('Font family used for body content in the app theme')),
-            Color::make(__('Primary color'), 'properties->theme->primary')
+            Color::make(__('Primary color'), 'primary_color')
                 ->hideFromIndex()
                 ->help(__('Primary color for the app theme (e.g. buttons, links)')),
-            Color::make(__('Default feature color'), 'properties->theme->defaultFeatureColor')
+            Color::make(__('Default feature color'), 'default_feature_color')
                 ->hideFromIndex()
                 ->help(__('Default color used for map features when no specific style is set')),
         ];

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -79,6 +79,7 @@ class App extends Resource
                 Tab::make('app', $this->app_tab()),
                 Tab::make('map', $this->map_tab()),
                 Tab::make('pois', $this->pois_tab()),
+                Tab::make('theme', $this->theme_tab()),
                 Tab::make('release_data', $this->app_release_data_tab()),
                 Tab::make('pages', $this->pages_tab()),
                 Tab::make('acquisition_form', $this->acquisition_form_tab()),
@@ -255,6 +256,24 @@ class App extends Resource
                 ->default(false)
                 ->hideFromIndex()
                 ->help(__('Shows the download tiles button on the map')),
+        ];
+    }
+
+    protected function theme_tab(): array
+    {
+        return [
+            Text::make(__('Font Family Header'), 'properties->theme->fontFamilyHeader')
+                ->hideFromIndex()
+                ->help(__('Font family used for headings in the app theme')),
+            Text::make(__('Font Family Content'), 'properties->theme->fontFamilyContent')
+                ->hideFromIndex()
+                ->help(__('Font family used for body content in the app theme')),
+            Color::make(__('Primary color'), 'properties->theme->primary')
+                ->hideFromIndex()
+                ->help(__('Primary color for the app theme (e.g. buttons, links)')),
+            Color::make(__('Default feature color'), 'properties->theme->defaultFeatureColor')
+                ->hideFromIndex()
+                ->help(__('Default color used for map features when no specific style is set')),
         ];
     }
 

--- a/src/Services/Models/App/AppConfigService.php
+++ b/src/Services/Models/App/AppConfigService.php
@@ -618,10 +618,7 @@ class AppConfigService extends AppBaseService
         $data = [];
         // THEME section
 
-        $data['THEME']['fontFamilyHeader'] = $this->app->properties['theme']['font_family_header'];
-        $data['THEME']['fontFamilyContent'] = $this->app->properties['theme']['font_family_content'];
-        $data['THEME']['defaultFeatureColor'] = $this->app->properties['theme']['default_feature_color'];
-        $data['THEME']['primary'] = $this->app->properties['theme']['primary_color'];
+        $data['THEME'] = $this->app->properties['theme'];
 
         return $data;
     }

--- a/src/Services/Models/App/AppConfigService.php
+++ b/src/Services/Models/App/AppConfigService.php
@@ -618,10 +618,10 @@ class AppConfigService extends AppBaseService
         $data = [];
         // THEME section
 
-        $data['THEME']['fontFamilyHeader'] = $this->app->font_family_header;
-        $data['THEME']['fontFamilyContent'] = $this->app->font_family_content;
-        $data['THEME']['defaultFeatureColor'] = $this->app->default_feature_color;
-        $data['THEME']['primary'] = $this->app->primary_color;
+        $data['THEME']['fontFamilyHeader'] = $this->app->properties['theme']['font_family_header'];
+        $data['THEME']['fontFamilyContent'] = $this->app->properties['theme']['font_family_content'];
+        $data['THEME']['defaultFeatureColor'] = $this->app->properties['theme']['default_feature_color'];
+        $data['THEME']['primary'] = $this->app->properties['theme']['primary_color'];
 
         return $data;
     }


### PR DESCRIPTION
- Introduced a new "theme" tab in the App resource to manage theme-related settings.
- Added fields for configuring font family and color options:
  - Font Family Header
  - Font Family Content
  - Primary color
  - Default feature color
- Each field includes help text and is hidden from the index view for a cleaner interface.
