### PR TITLE
feat(nova): ✨ add export tracks to GeoJSON action OC:7561

### DIFF
--- a/src/Nova/Actions/ExportTracksFeatureCollectionAction.php
+++ b/src/Nova/Actions/ExportTracksFeatureCollectionAction.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Wm\WmPackage\Nova\Actions;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Fields\ActionFields;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Wm\WmPackage\Models\Abstracts\MultiLineString;
+
+class ExportTracksFeatureCollectionAction extends Action
+{
+    /**
+     * Avoid writing one action log row per selected track on large selections.
+     *
+     * @var bool
+     */
+    public $withoutActionEvents = true;
+
+    public function name()
+    {
+        return __('Export tracks as GeoJSON');
+    }
+
+    public function handle(ActionFields $fields, Collection $models)
+    {
+        $models = $models->filter(fn ($m) => $m instanceof MultiLineString);
+        if ($models->isEmpty()) {
+            return Action::danger(__('No track models in the selection.'));
+        }
+
+        $appIds = $models->pluck('app_id')->filter()->unique();
+        if ($appIds->count() > 1) {
+            return Action::danger(__('All selected tracks must belong to the same app.'));
+        }
+
+        $featureCollection = [
+            'type' => 'FeatureCollection',
+            'features' => [],
+        ];
+
+        foreach ($models as $track) {
+            $feature = $track->getGeojson();
+            if (is_array($feature)) {
+                $featureCollection['features'][] = $feature;
+            }
+        }
+
+        if ($featureCollection['features'] === []) {
+            return Action::danger(__('No valid geometry found for the selected tracks.'));
+        }
+
+        $fileName = sprintf(
+            'tracks_export_%s.geojson',
+            now()->format('Y-m-d'),
+        );
+
+        Storage::disk('public')->put(
+            $fileName,
+            json_encode($featureCollection, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+        );
+
+        $signedUrl = URL::temporarySignedRoute(
+            'download.export',
+            now()->addMinutes(5),
+            ['fileName' => $fileName]
+        );
+
+        return Action::redirect($signedUrl);
+    }
+
+    public function fields(NovaRequest $request): array
+    {
+        return [];
+    }
+}

--- a/src/Nova/EcTrack.php
+++ b/src/Nova/EcTrack.php
@@ -12,6 +12,7 @@ use Laravel\Nova\Tabs\Tab;
 use Wm\WmPackage\Jobs\Track\UpdateEcTrackAwsJob;
 use Wm\WmPackage\Jobs\UpdateModelWithGeometryTaxonomyWhere;
 use Wm\WmPackage\Nova\Actions\ExecuteEcTrackDataChainAction;
+use Wm\WmPackage\Nova\Actions\ExportTracksFeatureCollectionAction;
 use Wm\WmPackage\Nova\Actions\TranslateModelAction;
 use Wm\WmPackage\Nova\Filters\FeaturesByLayerFilter;
 use Wm\WmPackage\Nova\Filters\FeaturesExcludeByIds;
@@ -80,6 +81,7 @@ class EcTrack extends AbstractEcResource
     public function actions(NovaRequest $request): array
     {
         return [
+            new ExportTracksFeatureCollectionAction,
             new Actions\ReindexSearchableAction,
             new ExecuteEcTrackDataChainAction([
                 fn ($ecTrack) => new UpdateEcTrackAwsJob($ecTrack),

--- a/src/Nova/UgcTrack.php
+++ b/src/Nova/UgcTrack.php
@@ -2,6 +2,8 @@
 
 namespace Wm\WmPackage\Nova;
 
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Wm\WmPackage\Nova\Actions\ExportTracksFeatureCollectionAction;
 use Wm\WmPackage\Nova\Traits\MultiLinestringResourceTrait;
 
 class UgcTrack extends AbstractUgcResource
@@ -18,5 +20,13 @@ class UgcTrack extends AbstractUgcResource
     public static function singularLabel(): string
     {
         return __('UGC Track');
+    }
+
+    public function actions(NovaRequest $request): array
+    {
+        return [
+            ...parent::actions($request),
+            new ExportTracksFeatureCollectionAction,
+        ];
     }
 }

--- a/tests/Unit/Nova/Actions/ExportTracksFeatureCollectionActionTest.php
+++ b/tests/Unit/Nova/Actions/ExportTracksFeatureCollectionActionTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Wm\WmPackage\Tests\Unit\Nova\Actions;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Nova\Actions\ActionResponse;
+use Laravel\Nova\Fields\ActionFields;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\EcTrack;
+use Wm\WmPackage\Nova\Actions\ExportTracksFeatureCollectionAction;
+use Wm\WmPackage\Tests\TestCase;
+
+class ExportTracksFeatureCollectionActionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('public');
+        Carbon::setTestNow(Carbon::parse('2026-04-16 10:00:00'));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_it_exports_selected_tracks_to_geojson_and_returns_signed_redirect_url()
+    {
+        $app = App::factory()->createQuietly();
+
+        $track1 = EcTrack::factory()->createQuietly(['app_id' => $app->id]);
+        $track2 = EcTrack::factory()->createQuietly(['app_id' => $app->id]);
+
+        $action = new ExportTracksFeatureCollectionAction();
+        $result = $action->handle(new ActionFields(collect(), collect()), collect([$track1, $track2]));
+
+        $this->assertInstanceOf(ActionResponse::class, $result);
+
+        $fileName = 'tracks_export_2026-04-16.geojson';
+        $this->assertTrue(Storage::disk('public')->exists($fileName));
+
+        $payload = json_decode(Storage::disk('public')->get($fileName), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame('FeatureCollection', $payload['type'] ?? null);
+        $this->assertCount(2, $payload['features'] ?? []);
+
+        foreach ($payload['features'] as $feature) {
+            $this->assertSame('Feature', $feature['type'] ?? null);
+        }
+
+        $encoded = json_encode($result, JSON_THROW_ON_ERROR);
+        $this->assertStringContainsString('redirect', $encoded);
+        $this->assertStringContainsString($fileName, $encoded);
+        $this->assertStringContainsString('signature=', $encoded);
+    }
+
+    public function test_it_rejects_selection_with_mixed_app_ids()
+    {
+        $app1 = App::factory()->createQuietly();
+        $app2 = App::factory()->createQuietly();
+
+        $track1 = EcTrack::factory()->createQuietly(['app_id' => $app1->id]);
+        $track2 = EcTrack::factory()->createQuietly(['app_id' => $app2->id]);
+
+        $action = new ExportTracksFeatureCollectionAction();
+        $result = $action->handle(new ActionFields(collect(), collect()), collect([$track1, $track2]));
+
+        $this->assertInstanceOf(ActionResponse::class, $result);
+        $this->assertStringContainsString(
+            'All selected tracks must belong to the same app.',
+            json_encode($result, JSON_THROW_ON_ERROR)
+        );
+    }
+
+    public function test_it_rejects_selection_without_track_models()
+    {
+        $app = App::factory()->createQuietly();
+
+        $action = new ExportTracksFeatureCollectionAction();
+        $result = $action->handle(new ActionFields(collect(), collect()), collect([$app]));
+
+        $this->assertInstanceOf(ActionResponse::class, $result);
+        $this->assertStringContainsString(
+            'No track models in the selection.',
+            json_encode($result, JSON_THROW_ON_ERROR)
+        );
+    }
+}
+


### PR DESCRIPTION
- Introduced `ExportTracksFeatureCollectionAction` to export selected tracks as a GeoJSON feature collection.
- Integrated the export action into `EcTrack` and `UgcTrack` resources.
- Ensured that the action checks for valid track models and app constraints before exporting.
- Generated a GeoJSON file stored in the public disk and provided a temporary signed URL for download.
