### PR TITLE
feat(Nova): ✨ add translatable tabs to taxonomy resource OC:7611

### DIFF
--- a/src/Nova/AbstractTaxonomyResource.php
+++ b/src/Nova/AbstractTaxonomyResource.php
@@ -13,6 +13,7 @@ use Laravel\Nova\Filters\Filter;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Lenses\Lens;
 use Laravel\Nova\Resource;
+use Kongulov\NovaTabTranslatable\NovaTabTranslatable;
 use Wm\WmPackage\Nova\Fields\IconSelect\IconSelect;
 
 abstract class AbstractTaxonomyResource extends Resource
@@ -43,7 +44,9 @@ abstract class AbstractTaxonomyResource extends Resource
     {
         return [
             ID::make()->sortable(),
-            Text::make('Name', 'name'),
+            NovaTabTranslatable::make([
+                Text::make('Name', 'name'),
+            ]),
             Textarea::make('Description', 'description'),
             IconSelect::make('Icona', 'icon')
                 ->loadFromIconsFile()
@@ -93,3 +96,4 @@ abstract class AbstractTaxonomyResource extends Resource
         return [];
     }
 }
+

--- a/src/Nova/AbstractTaxonomyResource.php
+++ b/src/Nova/AbstractTaxonomyResource.php
@@ -46,8 +46,8 @@ abstract class AbstractTaxonomyResource extends Resource
             ID::make()->sortable(),
             NovaTabTranslatable::make([
                 Text::make('Name', 'name'),
+                Textarea::make('Description', 'description'),
             ]),
-            Textarea::make('Description', 'description'),
             IconSelect::make('Icona', 'icon')
                 ->loadFromIconsFile()
                 ->searchPlaceholder('Cerca un\'icona per la tassonomia...')


### PR DESCRIPTION
- Integrate `NovaTabTranslatable` into `AbstractTaxonomyResource` to support multi-language translations.
- Wrap the `Text` field for 'Name' with `NovaTabTranslatable` to enable translatable tabs functionality.
- Enhance the usability of the taxonomy resource by allowing content translation directly within the Nova interface.
