### PR TITLE
feat(filter): ✨ add dynamic app_id filtering with UGC fallback OC:6075

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -4,6 +4,7 @@ namespace Wm\WmPackage\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use ChristianKuri\LaravelFavorite\Traits\Favoriteability;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -96,6 +97,23 @@ class User extends Authenticatable implements JWTSubject
     public function ugc_tracks(): HasMany
     {
         return $this->hasMany(UgcTrack::class);
+    }
+
+    /**
+     * Limit users to those who own at least one UGC POI or UGC track for the given app.
+     * Used by {@see \Wm\WmPackage\Nova\Filters\AppFilter} when the table has no `app_id` column.
+     * From a query builder: `Model::query()->getAppsFromUgc($appId)`.
+     */
+    public function scopeGetAppsFromUgc(Builder $query, mixed $appId): Builder
+    {
+        if (blank($appId)) {
+            return $query;
+        }
+
+        return $query->where(function (Builder $q) use ($appId) {
+            $q->whereHas('ugc_pois', fn (Builder $pois) => $pois->where('app_id', $appId))
+                ->orWhereHas('ugc_tracks', fn (Builder $tracks) => $tracks->where('app_id', $appId));
+        });
     }
 
     public function taxonomy_targets(): HasMany

--- a/src/Nova/Filters/AppFilter.php
+++ b/src/Nova/Filters/AppFilter.php
@@ -5,6 +5,7 @@ namespace Wm\WmPackage\Nova\Filters;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Laravel\Nova\Filters\Filter;
+use Illuminate\Support\Facades\Schema;
 use Wm\WmPackage\Models\App;
 
 class AppFilter extends Filter
@@ -28,6 +29,28 @@ class AppFilter extends Filter
      */
     public function apply(Request $request, $query, $value)
     {
+        if (blank($value)) {
+            return $query;
+        }
+
+        $model = $query->getModel();
+
+        $table = $model->getTable();
+        static $tableHasAppId = [];
+        $hasAppIdColumn = $tableHasAppId[$table] ??= Schema::hasColumn($table, 'app_id');
+
+        // If the table doesn't have `app_id` (e.g. users in this project), fall back to UGC relations.
+        if (!$hasAppIdColumn && method_exists($model, 'ugcPois') && method_exists($model, 'ugcTracks')) {
+            return $query->where(function (Builder $q) use ($value) {
+                $q->whereHas('ugcPois', function (Builder $ugcPois) use ($value) {
+                    $ugcPois->where('app_id', $value);
+                })->orWhereHas('ugcTracks', function (Builder $ugcTracks) use ($value) {
+                    $ugcTracks->where('app_id', $value);
+                });
+            });
+        }
+
+        // Default behaviour for resources that have a direct `app_id` column (UGC, Layer, etc.).
         return $query->where('app_id', $value);
     }
 

--- a/src/Nova/Filters/AppFilter.php
+++ b/src/Nova/Filters/AppFilter.php
@@ -4,8 +4,8 @@ namespace Wm\WmPackage\Nova\Filters;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Laravel\Nova\Filters\Filter;
 use Illuminate\Support\Facades\Schema;
+use Laravel\Nova\Filters\Filter;
 use Wm\WmPackage\Models\App;
 
 class AppFilter extends Filter
@@ -39,15 +39,9 @@ class AppFilter extends Filter
         static $tableHasAppId = [];
         $hasAppIdColumn = $tableHasAppId[$table] ??= Schema::hasColumn($table, 'app_id');
 
-        // If the table doesn't have `app_id` (e.g. users in this project), fall back to UGC relations.
-        if (!$hasAppIdColumn && method_exists($model, 'ugcPois') && method_exists($model, 'ugcTracks')) {
-            return $query->where(function (Builder $q) use ($value) {
-                $q->whereHas('ugcPois', function (Builder $ugcPois) use ($value) {
-                    $ugcPois->where('app_id', $value);
-                })->orWhereHas('ugcTracks', function (Builder $ugcTracks) use ($value) {
-                    $ugcTracks->where('app_id', $value);
-                });
-            });
+        // If the table doesn't have `app_id` (e.g. users), fall back to UGC relations via model scope.
+        if (!$hasAppIdColumn && method_exists($model, 'scopeGetAppsFromUgc')) {
+            return $query->getAppsFromUgc($value);
         }
 
         // Default behaviour for resources that have a direct `app_id` column (UGC, Layer, etc.).


### PR DESCRIPTION
- Introduced a check for a blank filter value to return the query unaltered.
- Added logic to verify if a model's table contains an `app_id` column using the Schema facade.
- Implemented a fallback mechanism for models lacking an `app_id` column by checking UGC relations.
- Enhanced the `apply` method to conditionally filter based on available columns or relationships.
- Ensured backward compatibility for resources with a direct `app_id` column.
