### PR TITLE
feat(localization): 🌐 add new tile layer selection description OC:7806

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -48,6 +48,7 @@
     "Layer Filter": "Layer Filter",
     "Layer Filter Label": "Layer Filter Label",
     "Select which layers will be available as filters": "Select which layers will be available as filters",
+    "Select which tile layers the app will use; order follows insertion order, so the last one inserted appears first on the map. The first tile type in the list is used to download tiles for offline mode in the frontend.": "Select which tile layers the app will use; order follows insertion order, so the last one inserted appears first on the map. The first tile type in the list is used to download tiles for offline mode in the frontend.",
     "Track Distance Step Filter": "Track Distance Step Filter",
     "Track Duration Steps Filter": "Track Duration Steps Filter",
     "Track Max Distance Filter": "Track Max Distance Filter",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -48,7 +48,7 @@
     "Layer Filter": "Layer Filter",
     "Layer Filter Label": "Layer Filter Label",
     "Select which layers will be available as filters": "Select which layers will be available as filters",
-    "Select which tile layers the app will use; order follows insertion order, so the last one inserted appears first on the map. The first tile type in the list is used to download tiles for offline mode in the frontend.": "Select which tile layers the app will use; order follows insertion order, so the last one inserted appears first on the map. The first tile type in the list is used to download tiles for offline mode in the frontend.",
+    "Select which tile layers the app will use; order follows insertion order. The first tile type in the list is used to download tiles for offline mode in the frontend.": "Select which tile layers the app will use; order follows insertion order. The first tile type in the list is used to download tiles for offline mode in the frontend.",
     "Track Distance Step Filter": "Track Distance Step Filter",
     "Track Duration Steps Filter": "Track Duration Steps Filter",
     "Track Max Distance Filter": "Track Max Distance Filter",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -48,6 +48,7 @@
     "Layer Filter": "Filtro livelli",
     "Layer Filter Label": "Etichetta filtro livelli",
     "Select which layers will be available as filters": "Seleziona quali livelli saranno disponibili come filtri",
+    "Select which tile layers the app will use; order follows insertion order, so the last one inserted appears first on the map. The first tile type in the list is used to download tiles for offline mode in the frontend.": "Seleziona quali layer di tiles utilizzerà l'app; l'ordine è quello di inserimento, quindi l'ultimo inserito sarà quello visibile per primo sulla mappa. La prima tipologia di tile presente nell'elenco viene utilizzata per il download delle tiles destinate alla modalità offline del frontend.",
     "Track Distance Step Filter": "Passi filtro distanza tracce",
     "Track Duration Steps Filter": "Passi filtro durata tracce",
     "Track Max Distance Filter": "Distanza massima filtro tracce",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -48,7 +48,7 @@
     "Layer Filter": "Filtro livelli",
     "Layer Filter Label": "Etichetta filtro livelli",
     "Select which layers will be available as filters": "Seleziona quali livelli saranno disponibili come filtri",
-    "Select which tile layers the app will use; order follows insertion order, so the last one inserted appears first on the map. The first tile type in the list is used to download tiles for offline mode in the frontend.": "Seleziona quali layer di tiles utilizzerà l'app; l'ordine è quello di inserimento, quindi l'ultimo inserito sarà quello visibile per primo sulla mappa. La prima tipologia di tile presente nell'elenco viene utilizzata per il download delle tiles destinate alla modalità offline del frontend.",
+    "Select which tile layers the app will use; order follows insertion order. The first tile type in the list is used to download tiles for offline mode in the frontend.": "Seleziona quali layer di tiles utilizzerà l'app; l'ordine è quello di inserimento. La prima tipologia di tile presente nell'elenco viene utilizzata per il download delle tiles destinate alla modalità offline del frontend.",
     "Track Distance Step Filter": "Passi filtro distanza tracce",
     "Track Duration Steps Filter": "Passi filtro durata tracce",
     "Track Max Distance Filter": "Distanza massima filtro tracce",

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -914,7 +914,7 @@ class App extends Resource
                 ->options($t, $selectedTileLayers)
                 ->reorderable()
                 ->hideFromIndex()
-                ->help(__('Select which tile layers will be used by the app, the order is the same as the insertion order, so the last one inserted will be the one visible first')),
+                ->help(__('Select which tile layers the app will use; order follows insertion order, so the last one inserted appears first on the map. The first tile type in the list is used to download tiles for offline mode in the frontend.')),
 
             // --- DATA CONTROLS ---
             Heading::make(

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -914,7 +914,7 @@ class App extends Resource
                 ->options($t, $selectedTileLayers)
                 ->reorderable()
                 ->hideFromIndex()
-                ->help(__('Select which tile layers the app will use; order follows insertion order, so the last one inserted appears first on the map. The first tile type in the list is used to download tiles for offline mode in the frontend.')),
+                ->help(__('Select which tile layers the app will use; order follows insertion order. The first tile type in the list is used to download tiles for offline mode in the frontend.')),
 
             // --- DATA CONTROLS ---
             Heading::make(


### PR DESCRIPTION
- Updated English and Italian localization files to include a detailed description for selecting tile layers.
- The description explains the order of tile layers and their usage for offline mode.
- Adjusted the help text in the `App.php` file to match the new localization entries.
