### PR TITLE
feat(config): ✨ add 'from' and 'to' fields to wm-elasticsearch configuration oc:7858

### DIFF
--- a/config/wm-elasticsearch.php
+++ b/config/wm-elasticsearch.php
@@ -50,6 +50,22 @@ return [
                     'end' => [
                         'type' => 'geo_point',
                     ],
+                    'from' => [
+                        'type' => 'text',
+                        'fields' => [
+                            'keyword' => [
+                                'type' => 'keyword',
+                            ],
+                        ],
+                    ],
+                    'to' => [
+                        'type' => 'text',
+                        'fields' => [
+                            'keyword' => [
+                                'type' => 'keyword',
+                            ],
+                        ],
+                    ],
                     'taxonomyActivities' => [
                         'type' => 'keyword',
                     ],

--- a/src/Models/EcTrack.php
+++ b/src/Models/EcTrack.php
@@ -728,8 +728,12 @@ class EcTrack extends MultiLineString implements LayerRelatedModel
             'end' => $end,
             'cai_scale' => $this->properties['cai_scale'] ?? '',
             'app_id' => $this->app_id,
-            // 'from' => $this->getActualOrOSFValue('from'),
-            // 'to' => $this->getActualOrOSFValue('to'),
+            'from' => $this->properties['from']
+                ?? data_get($this->osmfeatures_data ?? null, 'properties.from')
+                ?? '',
+            'to' => $this->properties['to']
+                ?? data_get($this->osmfeatures_data ?? null, 'properties.to')
+                ?? '',
             'name' => $this->getTranslation('name', 'it'),
             'taxonomyWheres' => $this->getOrderedTaxonomyWheres(),
             'feature_image' => $firstMedia ? $mediaService->getThumbnailUrl($firstMedia) : '',


### PR DESCRIPTION
- Introduced new 'from' and 'to' fields in the wm-elasticsearch configuration with 'text' type and 'keyword' subfields.
- Updated EcTrack model to retrieve 'from' and 'to' properties from the data source, enhancing data handling capabilities.
- This change improves the model's ability to manage additional properties related to track data.
