### PR TITLE
feat(command): ✨ add WmSyncUgcTaxonomyWhereCommand for UGC taxonomy synchronization oc:7377

### DIFF
--- a/database/factories/AppFactory.php
+++ b/database/factories/AppFactory.php
@@ -66,6 +66,9 @@ class AppFactory extends Factory
                 'show_duration_forward' => true,
                 'show_duration_backward' => true,
             ]),
+            'properties' => [
+                'theme' => [],
+            ],
         ];
     }
 }

--- a/database/factories/AppFactory.php
+++ b/database/factories/AppFactory.php
@@ -66,9 +66,6 @@ class AppFactory extends Factory
                 'show_duration_forward' => true,
                 'show_duration_backward' => true,
             ]),
-            'properties' => [
-                'theme' => [],
-            ],
         ];
     }
 }

--- a/src/Commands/WmSyncUgcTaxonomyWhereCommand.php
+++ b/src/Commands/WmSyncUgcTaxonomyWhereCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Wm\WmPackage\Commands;
+
+use Illuminate\Console\Command;
+use Wm\WmPackage\Jobs\UpdateModelWithGeometryTaxonomyWhere;
+use Wm\WmPackage\Models\UgcPoi;
+use Wm\WmPackage\Models\UgcTrack;
+
+class WmSyncUgcTaxonomyWhereCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'wm:sync-ugc-taxonomy-where
+                            {--type=all : Tipo UGC: all, poi, track}
+                            {--app-id= : Limita ai record con questo app_id}
+                            {--queue=geometric-computations : Coda su cui accodare i job}
+                            {--chunk=500 : Dimensione chunk per la query}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Accoda i job per ricalcolare properties.taxonomy_where (Osmfeatures) su UgcPoi e/o UgcTrack con geometria.';
+
+    public function handle(): int
+    {
+        $type = strtolower((string) $this->option('type'));
+        if (! in_array($type, ['all', 'poi', 'track', 'pois', 'tracks'], true)) {
+            $this->error('Opzione --type non valida: usare all, poi o track.');
+
+            return self::FAILURE;
+        }
+
+        $includePoi = in_array($type, ['all', 'poi', 'pois'], true);
+        $includeTrack = in_array($type, ['all', 'track', 'tracks'], true);
+
+        $queue = (string) $this->option('queue');
+        $chunk = max(1, (int) $this->option('chunk'));
+        $appId = $this->option('app-id');
+
+        $poiQuery = UgcPoi::query()->whereNotNull('geometry');
+        $trackQuery = UgcTrack::query()->whereNotNull('geometry');
+
+        if ($appId !== null && $appId !== '') {
+            $poiQuery->where('app_id', $appId);
+            $trackQuery->where('app_id', $appId);
+        }
+
+        $poiCount = $includePoi ? (clone $poiQuery)->count() : 0;
+        $trackCount = $includeTrack ? (clone $trackQuery)->count() : 0;
+        $total = $poiCount + $trackCount;
+
+        if ($total === 0) {
+            $this->warn('Nessun record UGC con geometria da elaborare.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Record da accodare: {$total} (UgcPoi: {$poiCount}, UgcTrack: {$trackCount}). Coda: {$queue}");
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $dispatch = function ($model) use ($queue, $bar): void {
+            $pending = new UpdateModelWithGeometryTaxonomyWhere($model);
+            if ($queue !== '') {
+                dispatch($pending)->onQueue($queue);
+            } else {
+                dispatch($pending);
+            }
+            $bar->advance();
+        };
+
+        if ($includePoi) {
+            $poiQuery->orderBy('id')->chunkById($chunk, function ($rows) use ($dispatch): void {
+                foreach ($rows as $poi) {
+                    $dispatch($poi);
+                }
+            });
+        }
+
+        if ($includeTrack) {
+            $trackQuery->orderBy('id')->chunkById($chunk, function ($rows) use ($dispatch): void {
+                foreach ($rows as $track) {
+                    $dispatch($track);
+                }
+            });
+        }
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Completato: {$total} job accodati.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Http/Controllers/Api/Abstracts/UgcController.php
+++ b/src/Http/Controllers/Api/Abstracts/UgcController.php
@@ -6,7 +6,9 @@ use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 use Wm\WmPackage\Http\Controllers\Controller;
+use Wm\WmPackage\Jobs\UpdateModelWithGeometryTaxonomyWhere;
 use Wm\WmPackage\Models\Abstracts\GeometryModel;
 use Wm\WmPackage\Services\GeometryComputationService;
 
@@ -43,6 +45,8 @@ abstract class UgcController extends Controller
 
         $model = $this->fillModelWithRequest($this->getModelIstance($request), $request, $validated);
 
+        $this->enrichUgcWithTaxonomyWhere($model);
+
         return response()->json(['id' => $model->id, 'message' => 'Created successfully'], 201);
     }
 
@@ -74,6 +78,8 @@ abstract class UgcController extends Controller
         $this->validateUser($model);
 
         $model = $this->fillModelWithRequest($model, $request, $validated);
+
+        $this->enrichUgcWithTaxonomyWhere($model);
 
         return response()->json(['id' => $model->id, 'message' => 'Updated successfully'], 200);
     }
@@ -160,5 +166,23 @@ abstract class UgcController extends Controller
         }
 
         return response()->json($featureCollection);
+    }
+
+    /**
+     * Runs taxonomy_where sync (osmfeatures) synchronously.
+     * On failure logs a warning, dispatches the same job asynchronously as fallback,
+     * and does not alter the successful HTTP response.
+     */
+    protected function enrichUgcWithTaxonomyWhere(GeometryModel $model): void
+    {
+        try {
+            UpdateModelWithGeometryTaxonomyWhere::dispatchSync($model);
+        } catch (Throwable $e) {
+            Log::channel('ugc')->warning('UpdateModelWithGeometryTaxonomyWhere failed: '.$e->getMessage(), [
+                'model' => $model::class,
+                'id' => $model->id,
+            ]);
+            UpdateModelWithGeometryTaxonomyWhere::dispatch($model);
+        }
     }
 }

--- a/src/Models/UgcPoi.php
+++ b/src/Models/UgcPoi.php
@@ -7,6 +7,8 @@ use Wm\WmPackage\Models\Abstracts\Point;
 use Wm\WmPackage\Models\Interfaces\UserOwnedModelInterface;
 use Wm\WmPackage\Observers\UgcObserver;
 use Wm\WmPackage\Traits\OwnedByUserModel;
+use Wm\WmPackage\Traits\TaxonomyAbleModel;
+use Wm\WmPackage\Traits\TaxonomyWhereAbleModel;
 
 /**
  * Class UgcPoi
@@ -23,7 +25,7 @@ use Wm\WmPackage\Traits\OwnedByUserModel;
  */
 class UgcPoi extends Point implements UserOwnedModelInterface
 {
-    use OwnedByUserModel;
+    use OwnedByUserModel, TaxonomyAbleModel, TaxonomyWhereAbleModel;
 
     /**
      * @var mixed|string

--- a/src/Models/UgcTrack.php
+++ b/src/Models/UgcTrack.php
@@ -7,6 +7,8 @@ use Wm\WmPackage\Models\Abstracts\MultiLineString;
 use Wm\WmPackage\Models\Interfaces\UserOwnedModelInterface;
 use Wm\WmPackage\Observers\UgcObserver;
 use Wm\WmPackage\Traits\OwnedByUserModel;
+use Wm\WmPackage\Traits\TaxonomyAbleModel;
+use Wm\WmPackage\Traits\TaxonomyWhereAbleModel;
 
 /**
  * Class UgcTrack
@@ -22,7 +24,7 @@ use Wm\WmPackage\Traits\OwnedByUserModel;
  */
 class UgcTrack extends MultiLineString implements UserOwnedModelInterface
 {
-    use OwnedByUserModel;
+    use OwnedByUserModel, TaxonomyAbleModel, TaxonomyWhereAbleModel;
 
     protected $fillable = [
         'user_id',

--- a/src/Nova/AbstractUgcResource.php
+++ b/src/Nova/AbstractUgcResource.php
@@ -8,6 +8,7 @@ use Laravel\Nova\Card;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\MorphToMany;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Wm\WmPackage\Nova\Actions\CopyUgc;
@@ -41,6 +42,9 @@ abstract class AbstractUgcResource extends AbstractGeometryResource
             PropertiesPanel::makeWithModel(__('Device'), 'properties->device', $this, false)->collapsible()->collapsedByDefault(),
             PropertiesPanel::makeWithModel(__('Nominatim'), 'properties->nominatim', $this, false)->collapsible()->collapsedByDefault(),
             PropertiesPanel::makeWithModel(__('Properties'), 'properties', $this, false)->collapsible()->collapsedByDefault(),
+            MorphToMany::make(__('Taxonomy Wheres'), 'taxonomyWheres', TaxonomyWhere::class)
+                ->display('name')
+                ->collapsedByDefault(),
             Images::make(__('Image'), 'default')->hideFromIndex(),
             Text::make(__('Media'))
                 ->resolveUsing(function ($value, $model) {

--- a/src/Services/Models/App/AppConfigService.php
+++ b/src/Services/Models/App/AppConfigService.php
@@ -634,7 +634,7 @@ class AppConfigService extends AppBaseService
         $data = [];
         // THEME section
 
-        $data['THEME'] = $this->app->properties['theme'];
+        $data['THEME'] = $this->app->properties['theme'] ?? [];
 
         return $data;
     }

--- a/src/WmPackageServiceProvider.php
+++ b/src/WmPackageServiceProvider.php
@@ -20,6 +20,7 @@ use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Tymon\JWTAuth\Providers\LaravelServiceProvider;
 use Wm\WmPackage\Commands\WmBackupCommand;
 use Wm\WmPackage\Commands\WmBuildAppPoisGeojsonCommand;
+use Wm\WmPackage\Commands\WmSyncUgcTaxonomyWhereCommand;
 use Wm\WmPackage\Commands\WmDownloadDbBackupCommand;
 use Wm\WmPackage\Commands\WmGenerateIconsCommand;
 use Wm\WmPackage\Commands\WmGeneratePBFCommand;
@@ -178,6 +179,7 @@ class WmPackageServiceProvider extends PackageServiceProvider
                 WmGeneratePBFCommand::class,
                 WmDownloadDbBackupCommand::class,
                 WmBuildAppPoisGeojsonCommand::class,
+                WmSyncUgcTaxonomyWhereCommand::class,
                 WmRestoreDbCommand::class,
                 WmGenerateIconsCommand::class,
             ])

--- a/tests/Feature/EcTrackToSearchableArrayFromToTest.php
+++ b/tests/Feature/EcTrackToSearchableArrayFromToTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Wm\WmPackage\Models\EcTrack;
+
+beforeEach(function () {
+    // Evita che EcTrackObserver::created dispatchi la chain di job (DEM, AWS, ecc.)
+    Bus::fake();
+
+    $fakeS3 = [
+        'driver' => 's3',
+        'key' => 'testing',
+        'secret' => 'testing',
+        'region' => 'eu-west-1',
+        'bucket' => 'test',
+        'url' => 'http://127.0.0.1:9000',
+        'endpoint' => 'http://127.0.0.1:9000',
+        'use_path_style_endpoint' => true,
+    ];
+    config([
+        'scout.driver' => null,
+        'wm-package.shard_name' => 'webmapp',
+        'filesystems.disks.s3' => $fakeS3,
+        'filesystems.disks.wmfe' => array_merge($fakeS3, ['bucket' => 'wmfe']),
+        'filesystems.disks.wmdumps' => array_merge($fakeS3, ['bucket' => 'wmdumps']),
+        'filesystems.disks.s3-osfmedia' => array_merge($fakeS3, ['bucket' => 'osfmedia']),
+    ]);
+});
+
+/** @return array<string, mixed> */
+function ecTrackTestProperties(array $overrides = []): array
+{
+    return array_merge([
+        'description' => 'Test description',
+        'excerpt' => 'Test excerpt',
+        'difficulty' => 'facile',
+        'rating' => 3,
+        'distance' => 5.0,
+        'ascent' => 100,
+        'descent' => 50,
+        'duration_forward' => 1.0,
+        'duration_backward' => 1.0,
+        'cai_scale' => 'T',
+        'ref' => 'AB-123',
+        'color' => '#FF0000',
+        'created_at' => now()->toDateTimeString(),
+    ], $overrides);
+}
+
+it('uses properties from and to when present', function () {
+    $from = 'Partenza Prop';
+    $to = 'Arrivo Prop';
+
+    /** @var EcTrack $track */
+    $track = EcTrack::factory()->create([
+        'properties' => ecTrackTestProperties([
+            'from' => $from,
+            'to' => $to,
+        ]),
+    ]);
+
+    $track->setAttribute('osmfeatures_data', [
+        'properties' => [
+            'from' => 'Da osmfeatures',
+            'to' => 'A osmfeatures',
+        ],
+    ]);
+
+    $arr = $track->toSearchableArray();
+
+    expect($arr['from'])->toBe($from)
+        ->and($arr['to'])->toBe($to);
+});
+
+it('falls back to osmfeatures_data properties when from or to missing in properties', function () {
+    /** @var EcTrack $track */
+    $track = EcTrack::factory()->create([
+        'properties' => ecTrackTestProperties(),
+    ]);
+
+    $track->setAttribute('osmfeatures_data', [
+        'properties' => [
+            'from' => 'Solo OSF',
+            'to' => 'Fine OSF',
+        ],
+    ]);
+
+    $arr = $track->toSearchableArray();
+
+    expect($arr['from'])->toBe('Solo OSF')
+        ->and($arr['to'])->toBe('Fine OSF');
+});
+
+it('returns empty strings when from and to are absent everywhere', function () {
+    /** @var EcTrack $track */
+    $track = EcTrack::factory()->create([
+        'properties' => ecTrackTestProperties(),
+    ]);
+
+    $arr = $track->toSearchableArray();
+
+    expect($arr['from'])->toBe('')
+        ->and($arr['to'])->toBe('');
+});

--- a/tests/Feature/UgcControllerTaxonomyWhereAsyncFallbackTest.php
+++ b/tests/Feature/UgcControllerTaxonomyWhereAsyncFallbackTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Bus\Dispatcher;
+use Illuminate\Support\Facades\Bus;
+use Wm\WmPackage\Http\Controllers\Api\Abstracts\UgcController;
+use Wm\WmPackage\Http\Controllers\Api\UgcPoiController;
+use Wm\WmPackage\Jobs\UpdateModelWithGeometryTaxonomyWhere;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\UgcPoi;
+use Wm\WmPackage\Models\User;
+
+beforeEach(function () {
+    // Evita che eventuali observer dispatchino job reali durante il setup dei modelli
+    Bus::fake();
+
+    $fakeS3 = [
+        'driver' => 's3',
+        'key' => 'testing',
+        'secret' => 'testing',
+        'region' => 'eu-west-1',
+        'bucket' => 'test',
+        'url' => 'http://127.0.0.1:9000',
+        'endpoint' => 'http://127.0.0.1:9000',
+        'use_path_style_endpoint' => true,
+    ];
+    config([
+        'wm-package.shard_name' => 'webmapp',
+        'filesystems.disks.s3' => $fakeS3,
+        'filesystems.disks.wmfe' => array_merge($fakeS3, ['bucket' => 'wmfe']),
+        'filesystems.disks.wmdumps' => array_merge($fakeS3, ['bucket' => 'wmdumps']),
+        'filesystems.disks.s3-osfmedia' => array_merge($fakeS3, ['bucket' => 'osfmedia']),
+    ]);
+});
+
+afterEach(function () {
+    \Mockery::close();
+});
+
+it('dispatches UpdateModelWithGeometryTaxonomyWhere async when dispatchSync fails', function () {
+    $user = User::factory()->create();
+    $app = App::factory()->create();
+
+    /** @var UgcPoi $poi */
+    $poi = UgcPoi::factory()->create([
+        'user_id' => $user->id,
+        'app_id' => $app->id,
+    ]);
+
+    // Mock del Dispatcher così possiamo distinguere dispatchSync (che fallisce) da dispatch (async)
+    $dispatcher = \Mockery::mock(Dispatcher::class);
+    $dispatcher->shouldReceive('dispatchSync')
+        ->once()
+        ->with(\Mockery::type(UpdateModelWithGeometryTaxonomyWhere::class))
+        ->andThrow(new RuntimeException('simulated dispatchSync failure'));
+    $dispatcher->shouldReceive('dispatch')
+        ->once()
+        ->with(\Mockery::type(UpdateModelWithGeometryTaxonomyWhere::class));
+
+    app()->instance(Dispatcher::class, $dispatcher);
+
+    $controller = app(UgcPoiController::class);
+    $method = new \ReflectionMethod(UgcController::class, 'enrichUgcWithTaxonomyWhere');
+    $method->setAccessible(true);
+    $method->invoke($controller, $poi);
+
+    // Le assertion Mockery vengono validate al teardown via shouldReceive('...')->once()
+    expect(true)->toBeTrue();
+});
+
+it('does not push async job when dispatchSync completes without throwing', function () {
+    $user = User::factory()->create();
+    $app = App::factory()->create();
+
+    /** @var UgcPoi $poi */
+    $poi = UgcPoi::factory()->create([
+        'user_id' => $user->id,
+        'app_id' => $app->id,
+    ]);
+
+    $dispatcher = \Mockery::mock(Dispatcher::class);
+    $dispatcher->shouldReceive('dispatchSync')
+        ->once()
+        ->with(\Mockery::type(UpdateModelWithGeometryTaxonomyWhere::class));
+    $dispatcher->shouldNotReceive('dispatch');
+
+    app()->instance(Dispatcher::class, $dispatcher);
+
+    $controller = app(UgcPoiController::class);
+    $method = new \ReflectionMethod(UgcController::class, 'enrichUgcWithTaxonomyWhere');
+    $method->setAccessible(true);
+    $method->invoke($controller, $poi);
+
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
- Introduced a new command `wm:sync-ugc-taxonomy-where` to queue jobs for recalculating `properties.taxonomy_where` on `UgcPoi` and `UgcTrack` models with geometry.
- Updated `WmPackageServiceProvider` to register the new command.
- Enhanced `UgcController` to call the new command synchronously and handle failures gracefully by dispatching jobs asynchronously as a fallback.
- Updated `UgcPoi` and `UgcTrack` models to include new traits for taxonomy capabilities.
- Added a new relationship field in the Nova resource for displaying associated taxonomy wheres.
