### PR TITLE
fix(config): 🐛 resolve URL fallback logic for wmfeUrl OC:7896

### DIFF
--- a/src/Nova/Cards/ApiLinksCard/src/EcTrackApiLinksCard.php
+++ b/src/Nova/Cards/ApiLinksCard/src/EcTrackApiLinksCard.php
@@ -11,7 +11,7 @@ class EcTrackApiLinksCard extends ApiLinksCard
     public function __construct(EcTrack $track)
     {
         $shardName = config('wm-package.shard_name', config('app.name'));
-        $wmfeUrl = rtrim(config('filesystems.disks.wmfe.url', config('app.url').'/wmfe'), '/');
+        $wmfeUrl = rtrim(config('filesystems.disks.wmfe.url') ?: config('app.url').'/wmfe', '/');
 
         parent::__construct([
             [


### PR DESCRIPTION
- Correct the fallback logic for `$wmfeUrl` to ensure the default URL is used when the configuration value is absent.
- Utilize the null coalescing operator to streamline the conditional URL assignment.
