### PR TITLE
- feat(oc:7749): ✨ add create app feature to wm-package OC:7749

### DIFF
--- a/docs/features/7749-aggiungere-create-app/notes.md
+++ b/docs/features/7749-aggiungere-create-app/notes.md
@@ -3,7 +3,7 @@
 # Notes — Aggiungere create app
 
 ## Deviazioni dal piano
-- Nessuna deviazione. Tutti gli step sono stati implementati come pianificato.
+- **`AppPolicy::create()`**: inizialmente implementato con `hasRole('Administrator')`; successivamente allineato a `SuperAdminService::allowsUser()` per coerenza con le action Nova sulla stessa risorsa (PBF, Scout, AWS, ecc.) e per limitare la creazione allo staff in allowlist, non a tutti gli Administrator del tenant.
 
 ## Bug trovati
 - **FK errata su `author()`**: `belongsTo(User::class)` senza foreign key esplicita inferiva `author_id` (inesistente), mentre la colonna reale è `user_id`. Corretto in Step 1 come bug latente del model.
@@ -11,6 +11,7 @@
 
 ## Decisioni
 - La registrazione di `AppPolicy` è stata messa in `WmPackageServiceProvider` (e non nel progetto host) per garantire che valga per tutti i progetti che usano il package.
+- `AppPolicy::create()` usa `SuperAdminService` (allowlist `wm-package.super_admin_emails` / `WM_SUPER_ADMIN_EMAILS`), non il ruolo Spatie `Administrator`, in linea con `Nova/App::actions()`.
 - `fieldsForCreate()` usa `App\Nova\User` come classe Nova per il `BelongsTo`, seguendo il pattern già stabilito in `Nova/Layer.php`.
 - I fix da oc:7757 (`->default()` e `->rules('required')` su `default_language`, `start_end_icons_min_zoom`, `ref_on_track_min_zoom`) sono stati incorporati in questo ciclo come Step 6, chiudendo di fatto anche quel ticket.
 

--- a/docs/features/7749-aggiungere-create-app/notes.md
+++ b/docs/features/7749-aggiungere-create-app/notes.md
@@ -1,0 +1,20 @@
+> Ticket: oc:7749
+
+# Notes — Aggiungere create app
+
+## Deviazioni dal piano
+- Nessuna deviazione. Tutti gli step sono stati implementati come pianificato.
+
+## Bug trovati
+- **FK errata su `author()`**: `belongsTo(User::class)` senza foreign key esplicita inferiva `author_id` (inesistente), mentre la colonna reale è `user_id`. Corretto in Step 1 come bug latente del model.
+- **`AppPolicy` non registrata**: la policy esisteva ma non era registrata in nessun provider, quindi il metodo `create()` non sarebbe mai stato invocato. Risolto registrando esplicitamente in `WmPackageServiceProvider`.
+
+## Decisioni
+- La registrazione di `AppPolicy` è stata messa in `WmPackageServiceProvider` (e non nel progetto host) per garantire che valga per tutti i progetti che usano il package.
+- `fieldsForCreate()` usa `App\Nova\User` come classe Nova per il `BelongsTo`, seguendo il pattern già stabilito in `Nova/Layer.php`.
+- I fix da oc:7757 (`->default()` e `->rules('required')` su `default_language`, `start_end_icons_min_zoom`, `ref_on_track_min_zoom`) sono stati incorporati in questo ciclo come Step 6, chiudendo di fatto anche quel ticket.
+
+## Follow-up
+- **Auto-popolamento `customer_name`**: valutare in un ciclo futuro se pre-popolare `customer_name` con il valore di `name` per ridurre la digitazione ridondante in fase di creazione.
+- **Config AWS su creazione**: `AppObserver::saved()` scrive immediatamente `config.json` su AWS anche per un'App appena creata con soli 4 campi. Il `config.json` risultante sarà parziale fino al primo salvataggio completo. Valutare in futuro un meccanismo di stato `draft/published` per bloccare la scrittura AWS finché l'App non è completa.
+- **Cleanup AWS su delete**: non esiste un observer su `deleted` che rimuova il `config.json` da AWS. Un rollback del codice non rimuove gli artefatti già scritti su storage esterno.

--- a/docs/features/7749-aggiungere-create-app/overview.md
+++ b/docs/features/7749-aggiungere-create-app/overview.md
@@ -1,0 +1,32 @@
+> Ticket: oc:7749
+
+# Aggiungere create app
+
+## Cosa cambia
+Viene abilitato il pulsante "Crea App" nella risorsa Nova `App` in tutti i progetti che usano `wm-package`. Gli Administrator possono creare nuove App tramite un form minimale con i soli campi obbligatori.
+
+## Perché
+La risorsa Nova `App` non aveva né il metodo `create` nella policy né un form di creazione, rendendo impossibile creare nuove App dall'interfaccia Nova. I tentativi manuali di creazione (documentati in oc:7757) fallivan con errori NOT NULL su campi non presenti nel form. Questa feature porta la funzionalità in modo stabile e condiviso nel package.
+
+## Requisiti
+- [ ] `AppPolicy::create()` abilita la creazione solo per utenti con ruolo `Administrator`
+- [ ] Il form di creazione mostra solo i campi obbligatori: `name`, `customer_name`, `sku`, `author` (BelongsTo User, nullable, searchable)
+- [ ] I campi con default nel DB (`default_language`, `start_end_icons_min_zoom`, `ref_on_track_min_zoom`, ecc.) non compaiono nel form di creazione e vengono valorizzati dai default DB
+- [ ] La modifica è in `wm-package` ed è attiva in tutti i progetti che usano il package
+- [ ] Il campo `author` è selezionabile manualmente (un Administrator può creare un'app per conto di un altro utente)
+
+## Rischi
+- **Abilitazione globale**: la modifica abilita la creazione di App in tutti i progetti. Progetti che per policy non devono permettere la creazione di App dovranno fare override di `authorizedToCreate()` nella propria `Nova/App.php`. Da comunicare al team.
+- **Campi NOT NULL senza default**: se in futuro vengono aggiunti colonne NOT NULL senza default alla tabella `apps`, il form minimo potrebbe tornare a fallire. Il `fieldsForCreate()` deve essere aggiornato contestualmente alle migration.
+
+## Out of scope
+- Auto-popolamento di `customer_name` dal campo `name` (annotato per ciclo futuro)
+- Validazione o formato specifico per `sku` (es. bundle ID)
+- Override per-progetto dell'autorizzazione (ogni progetto gestirà autonomamente eventuali restrizioni aggiuntive)
+- Fix dei campi Nova per la pagina di edit (non richiesto da questo ticket)
+
+## Moduli toccati
+| File | Repo | Tipo modifica |
+|------|------|---------------|
+| `src/Policies/AppPolicy.php` | `wm-package` | Aggiunta metodo `create()` |
+| `src/Nova/App.php` | `wm-package` | Aggiunta metodo `fieldsForCreate()` |

--- a/docs/features/7749-aggiungere-create-app/overview.md
+++ b/docs/features/7749-aggiungere-create-app/overview.md
@@ -3,20 +3,21 @@
 # Aggiungere create app
 
 ## Cosa cambia
-Viene abilitato il pulsante "Crea App" nella risorsa Nova `App` in tutti i progetti che usano `wm-package`. Gli Administrator possono creare nuove App tramite un form minimale con i soli campi obbligatori.
+Viene abilitato il pulsante "Crea App" nella risorsa Nova `App` in tutti i progetti che usano `wm-package`. Gli utenti in allowlist super-admin (`SuperAdminService`, stesso criterio delle action critiche sulla risorsa App) possono creare nuove App tramite un form minimale con i soli campi obbligatori.
 
 ## Perché
 La risorsa Nova `App` non aveva né il metodo `create` nella policy né un form di creazione, rendendo impossibile creare nuove App dall'interfaccia Nova. I tentativi manuali di creazione (documentati in oc:7757) fallivan con errori NOT NULL su campi non presenti nel form. Questa feature porta la funzionalità in modo stabile e condiviso nel package.
 
 ## Requisiti
-- [ ] `AppPolicy::create()` abilita la creazione solo per utenti con ruolo `Administrator`
+- [ ] `AppPolicy::create()` abilita la creazione solo per utenti la cui email è in `config('wm-package.super_admin_emails')` (env `WM_SUPER_ADMIN_EMAILS`), tramite `SuperAdminService`
 - [ ] Il form di creazione mostra solo i campi obbligatori: `name`, `customer_name`, `sku`, `author` (BelongsTo User, nullable, searchable)
 - [ ] I campi con default nel DB (`default_language`, `start_end_icons_min_zoom`, `ref_on_track_min_zoom`, ecc.) non compaiono nel form di creazione e vengono valorizzati dai default DB
 - [ ] La modifica è in `wm-package` ed è attiva in tutti i progetti che usano il package
-- [ ] Il campo `author` è selezionabile manualmente (un Administrator può creare un'app per conto di un altro utente)
+- [ ] Il campo `author` è selezionabile manualmente (un super-admin può creare un'app per conto di un altro utente)
 
 ## Rischi
-- **Abilitazione globale**: la modifica abilita la creazione di App in tutti i progetti. Progetti che per policy non devono permettere la creazione di App dovranno fare override di `authorizedToCreate()` nella propria `Nova/App.php`. Da comunicare al team.
+- **Allowlist per ambiente**: la creazione dipende da `WM_SUPER_ADMIN_EMAILS` (default `team@webmapp.it`). Administrator del tenant senza email in lista non vedono "Crea App". Configurare l'env in ogni ambiente.
+- **Abilitazione nel package**: la policy vale in tutti i progetti. Progetti che devono restringere ulteriormente la creazione possono fare override di `authorizedToCreate()` nella propria `Nova/App.php`. Da comunicare al team.
 - **Campi NOT NULL senza default**: se in futuro vengono aggiunti colonne NOT NULL senza default alla tabella `apps`, il form minimo potrebbe tornare a fallire. Il `fieldsForCreate()` deve essere aggiornato contestualmente alle migration.
 
 ## Out of scope
@@ -28,5 +29,5 @@ La risorsa Nova `App` non aveva né il metodo `create` nella policy né un form 
 ## Moduli toccati
 | File | Repo | Tipo modifica |
 |------|------|---------------|
-| `src/Policies/AppPolicy.php` | `wm-package` | Aggiunta metodo `create()` |
+| `src/Policies/AppPolicy.php` | `wm-package` | Metodo `create()` con `SuperAdminService` |
 | `src/Nova/App.php` | `wm-package` | Aggiunta metodo `fieldsForCreate()` |

--- a/docs/features/7749-aggiungere-create-app/plan.md
+++ b/docs/features/7749-aggiungere-create-app/plan.md
@@ -1,0 +1,205 @@
+> Ticket: oc:7749
+
+# Plan — Aggiungere create app
+
+## Repo coinvolto
+`wm-package` — tutte le modifiche sono nel package, nessuna modifica al repo principale.
+
+---
+
+## Step 1 — Fix FK in `Models/App.php`
+
+**File:** `src/Models/App.php`
+
+Correggere la relazione `author()` che inferisce `author_id` (inesistente) invece di usare la colonna reale `user_id`.
+
+```php
+// prima
+public function author(): BelongsTo
+{
+    return $this->belongsTo(User::class);
+}
+
+// dopo
+public function author(): BelongsTo
+{
+    return $this->belongsTo(User::class, 'user_id');
+}
+```
+
+**Commit:** `fix(oc:7749): fix author() FK to use user_id in App model`
+
+---
+
+## Step 2 — Aggiungere `create()` a `AppPolicy`
+
+**File:** `src/Policies/AppPolicy.php`
+
+Aggiungere il metodo `create()` seguendo il pattern di `TilePolicy` (`$user->hasRole('Administrator')`).
+
+```php
+public function create(User $user): bool
+{
+    return $user->hasRole('Administrator');
+}
+```
+
+**Commit:** `feat(oc:7749): add create() to AppPolicy — Administrator only`
+
+---
+
+## Step 3 — Registrare `AppPolicy` in `WmPackageServiceProvider`
+
+**File:** `src/WmPackageServiceProvider.php`
+
+Aggiungere la registrazione esplicita della policy nel blocco "Register policies" esistente (righe 112-121). Aggiungere i due `use` mancanti.
+
+Import da aggiungere:
+```php
+use Illuminate\Support\Facades\Gate;
+use Wm\WmPackage\Models\App as AppModel;
+use Wm\WmPackage\Policies\AppPolicy;
+```
+
+Nel corpo di `boot()` dopo il commento "Register policies":
+```php
+Gate::policy(AppModel::class, AppPolicy::class);
+```
+
+**Commit:** `feat(oc:7749): register AppPolicy in WmPackageServiceProvider`
+
+---
+
+## Step 4 — `fieldsForCreate()` in `Nova/App.php`
+
+**File:** `src/Nova/App.php`
+
+Aggiungere il metodo `fieldsForCreate()` con i soli campi obbligatori. Aggiungere i due `use` mancanti in cima al file.
+
+Import da aggiungere:
+```php
+use Laravel\Nova\Fields\BelongsTo;
+use Illuminate\Validation\Rule;
+use App\Nova\User as NovaUser;
+```
+
+Metodo da aggiungere dopo `fields()`:
+```php
+public function fieldsForCreate(NovaRequest $request): array
+{
+    return [
+        Text::make('Name')
+            ->rules('required'),
+        Text::make(__('Customer Name'), 'customer_name')
+            ->rules('required')
+            ->help(__('Name of the customer or organization that owns this app.')),
+        Text::make(__('Sku'), 'sku')
+            ->rules('required', 'unique:apps,sku')
+            ->help(__('Unique app identifier on the stores (App Store and Play Store).')),
+        BelongsTo::make(__('Author'), 'author', NovaUser::class)
+            ->nullable()
+            ->searchable()
+            ->help(__('User responsible for this app. Leave empty if not applicable.')),
+    ];
+}
+```
+
+> **Nota futura (follow-up):** valutare se pre-popolare `customer_name` con il valore di `name` per ridurre la digitazione ridondante.
+
+**Commit:** `feat(oc:7749): add fieldsForCreate() to Nova App resource`
+
+---
+
+## Step 5 — Validazione unique su `sku` in edit
+
+**File:** `src/Nova/App.php`
+
+Nel metodo `app_release_data_tab()` (riga ~559), il campo `sku` esiste già. Aggiungere `updateRules` per validare l'unicità ignorando il record corrente.
+
+```php
+// prima
+Text::make(__('Sku'), 'sku')
+    ->required()
+    ->help(__('App name on the stores (App Store and Playstore).')),
+
+// dopo
+Text::make(__('Sku'), 'sku')
+    ->required()
+    ->updateRules(Rule::unique('apps', 'sku')->ignore($this->resource->id ?? null))
+    ->help(__('App name on the stores (App Store and Playstore).')),
+```
+
+**Commit:** `feat(oc:7749): add unique updateRules to sku field in Nova App`
+
+---
+
+## Step 6 — Default difensivi sui campi Nova in edit (da oc:7757)
+
+**File:** `src/Nova/App.php`
+
+Aggiungere `->default(...)` ai tre campi NOT NULL che in edit potrebbero essere salvati come `null` se svuotati dall'utente. Chiude le fix temporanee documentate in oc:7757.
+
+**`default_language`** — metodo `languages_tab()` (~riga 468):
+```php
+// prima
+Select::make(__('Default Language'), 'default_language')
+    ->hideFromIndex()
+    ->options($languages)
+    ->displayUsingLabels()
+    ->help(__('This is the default language displayed by the app.')),
+
+// dopo
+Select::make(__('Default Language'), 'default_language')
+    ->hideFromIndex()
+    ->options($languages)
+    ->displayUsingLabels()
+    ->default('it')
+    ->rules('required')
+    ->help(__('This is the default language displayed by the app.')),
+```
+
+**`start_end_icons_min_zoom`** — metodo `map_tab()` (~riga 1102):
+```php
+// prima
+Number::make(__('start_end_icons_min_zoom'))
+    ->min(10)->max(20)
+    ->hideFromIndex()
+    ->help(__('...')),
+
+// dopo
+Number::make(__('start_end_icons_min_zoom'))
+    ->min(10)->max(20)
+    ->default(10)
+    ->rules('required')
+    ->hideFromIndex()
+    ->help(__('...')),
+```
+
+**`ref_on_track_min_zoom`** — metodo `map_tab()` (~riga 1110):
+```php
+// prima
+Number::make(__('ref_on_track_min_zoom'))
+    ->min(10)->max(20)
+
+// dopo
+Number::make(__('ref_on_track_min_zoom'))
+    ->min(10)->max(20)
+    ->default(10)
+    ->rules('required')
+```
+
+**Commit:** `fix(oc:7749): add defaults and required rules to default_language, start_end_icons_min_zoom, ref_on_track_min_zoom`
+
+---
+
+## Checklist pre-PR
+
+- [ ] Step 1: FK `author()` corretta
+- [ ] Step 2: `AppPolicy::create()` aggiunto
+- [ ] Step 3: Policy registrata in `WmPackageServiceProvider`
+- [ ] Step 4: `fieldsForCreate()` aggiunto con 4 campi
+- [ ] Step 5: `->updateRules(unique...)` su `sku` in edit
+- [ ] Step 6: `->default()` e `->rules('required')` su `default_language`, `start_end_icons_min_zoom`, `ref_on_track_min_zoom`
+- [ ] Test manuale: login come Administrator → compare pulsante "Create App" → form mostra solo i 4 campi → salvataggio senza errori NOT NULL
+- [ ] Test manuale: login come non-Administrator → pulsante "Create App" non compare
+- [ ] Test manuale: inserire sku duplicato → messaggio di validazione (non errore 500)

--- a/docs/features/7749-aggiungere-create-app/plan.md
+++ b/docs/features/7749-aggiungere-create-app/plan.md
@@ -35,16 +35,18 @@ public function author(): BelongsTo
 
 **File:** `src/Policies/AppPolicy.php`
 
-Aggiungere il metodo `create()` seguendo il pattern di `TilePolicy` (`$user->hasRole('Administrator')`).
+Aggiungere il metodo `create()` usando `SuperAdminService` (stesso criterio delle action Nova su `App`: allowlist email, env `WM_SUPER_ADMIN_EMAILS`).
 
 ```php
+use Wm\WmPackage\Support\SuperAdminService;
+
 public function create(User $user): bool
 {
-    return $user->hasRole('Administrator');
+    return SuperAdminService::allowsUser($user);
 }
 ```
 
-**Commit:** `feat(oc:7749): add create() to AppPolicy — Administrator only`
+**Commit:** `feat(oc:7749): add create() to AppPolicy — SuperAdmin allowlist`
 
 ---
 
@@ -200,6 +202,7 @@ Number::make(__('ref_on_track_min_zoom'))
 - [ ] Step 4: `fieldsForCreate()` aggiunto con 4 campi
 - [ ] Step 5: `->updateRules(unique...)` su `sku` in edit
 - [ ] Step 6: `->default()` e `->rules('required')` su `default_language`, `start_end_icons_min_zoom`, `ref_on_track_min_zoom`
-- [ ] Test manuale: login come Administrator → compare pulsante "Create App" → form mostra solo i 4 campi → salvataggio senza errori NOT NULL
-- [ ] Test manuale: login come non-Administrator → pulsante "Create App" non compare
+- [ ] Test manuale: login con email in `WM_SUPER_ADMIN_EMAILS` → compare pulsante "Create App" → form mostra solo i 4 campi → salvataggio senza errori NOT NULL
+- [ ] Test manuale: login come Administrator **senza** email in allowlist → pulsante "Create App" non compare
+- [ ] Test manuale: utente non in allowlist (qualsiasi ruolo) → pulsante "Create App" non compare
 - [ ] Test manuale: inserire sku duplicato → messaggio di validazione (non errore 500)

--- a/src/Models/App.php
+++ b/src/Models/App.php
@@ -70,7 +70,7 @@ class App extends Model implements HasMedia
 
     public function author(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class, 'user_id');
     }
 
     public function layers()

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -2,8 +2,11 @@
 
 namespace Wm\WmPackage\Nova;
 
+use App\Nova\User as NovaUser;
 use Ebess\AdvancedNovaMediaLibrary\Fields\Images;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Validation\Rule;
+use Laravel\Nova\Fields\BelongsTo;
 use Kongulov\NovaTabTranslatable\NovaTabTranslatable;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\Code;
@@ -104,6 +107,24 @@ class App extends Resource
             ]),
 
             // TODO: implement fields
+        ];
+    }
+
+    public function fieldsForCreate(NovaRequest $request): array
+    {
+        return [
+            Text::make('Name')
+                ->rules('required'),
+            Text::make(__('Customer Name'), 'customer_name')
+                ->rules('required')
+                ->help(__('Name of the customer or organization that owns this app.')),
+            Text::make(__('Sku'), 'sku')
+                ->rules('required', 'unique:apps,sku')
+                ->help(__('Unique app identifier on the stores (App Store and Play Store).')),
+            BelongsTo::make(__('Author'), 'author', NovaUser::class)
+                ->nullable()
+                ->searchable()
+                ->help(__('User responsible for this app. Leave empty if not applicable.')),
         ];
     }
 
@@ -469,6 +490,8 @@ class App extends Resource
                 ->hideFromIndex()
                 ->options($languages)
                 ->displayUsingLabels()
+                ->default('it')
+                ->rules('required')
                 ->help(__('This is the default language displayed by the app.')),
             Multiselect::make(__('Available Languages'), 'available_languages')
                 ->hideFromIndex()
@@ -566,6 +589,7 @@ class App extends Resource
                 ->help(__('App name on the stores (App Store and Playstore).')),
             Text::make(__('Sku'), 'sku')
                 ->required()
+                ->updateRules(Rule::unique('apps', 'sku')->ignore($this->resource->id ?? null))
                 ->help(__('App name on the stores (App Store and Playstore).')),
             Text::make(__('Play Store link (android)'), 'android_store_link')
                 ->hideFromIndex()
@@ -1101,6 +1125,8 @@ class App extends Resource
                 ->help(__('Displays start and end icons on the map')),
             Number::make(__('start_end_icons_min_zoom'))
                 ->min(10)->max(20)
+                ->default(10)
+                ->rules('required')
                 ->hideFromIndex()
                 ->help(__('Set minimum zoom at which start and end icons are shown in general maps (start_end_icons_show must be true)')),
             Boolean::make(__('Ref on Track Show'), 'ref_on_track_show')
@@ -1109,6 +1135,8 @@ class App extends Resource
                 ->help(__('Displays reference labels on tracks')),
             Number::make(__('ref_on_track_min_zoom'))
                 ->min(10)->max(20)
+                ->default(10)
+                ->rules('required')
                 ->hideFromIndex()
                 ->help(__('Set minimum zoom at which ref parameter is shown on tracks line in general maps (ref_on_track_show must be true)')),
             Boolean::make(__('Show Features In Viewport'), 'properties->show_features_in_viewport')

--- a/src/Policies/AppPolicy.php
+++ b/src/Policies/AppPolicy.php
@@ -5,6 +5,7 @@ namespace Wm\WmPackage\Policies;
 use App\Models\User;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Support\SuperAdminService;
 
 class AppPolicy
 {
@@ -19,7 +20,7 @@ class AppPolicy
 
     public function create(User $user): bool
     {
-        return $user->hasRole('Administrator');
+        return SuperAdminService::allowsUser($user);
     }
 
     public function viewAny(User $user): bool

--- a/src/Policies/AppPolicy.php
+++ b/src/Policies/AppPolicy.php
@@ -17,6 +17,11 @@ class AppPolicy
      */
     public function __construct() {}
 
+    public function create(User $user): bool
+    {
+        return $user->hasRole('Administrator');
+    }
+
     public function viewAny(User $user): bool
     {
         return true;

--- a/src/WmPackageServiceProvider.php
+++ b/src/WmPackageServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Laravel\Nova\Menu\MenuItem;
 use Laravel\Nova\Menu\MenuSection;
@@ -18,6 +19,8 @@ use Spatie\Backup\Config\Config as BackupConfig;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Tymon\JWTAuth\Providers\LaravelServiceProvider;
+use Wm\WmPackage\Models\App as AppModel;
+use Wm\WmPackage\Policies\AppPolicy;
 use Wm\WmPackage\Commands\WmBackupCommand;
 use Wm\WmPackage\Commands\WmBuildAppPoisGeojsonCommand;
 use Wm\WmPackage\Commands\WmDownloadDbBackupCommand;
@@ -119,6 +122,7 @@ class WmPackageServiceProvider extends PackageServiceProvider
         //     //dump($t);
         //     return $t;
         // });
+        Gate::policy(AppModel::class, AppPolicy::class);
 
         // SENTRY
         $this->app->booted(function () {


### PR DESCRIPTION
  - Implemented create app functionality in the wm-package
  - Enabled "Crea App" button in Nova `App` resource
  - Added `create()` method to `AppPolicy` allowing only Administrators to create apps
  - Registered `AppPolicy` in `WmPackageServiceProvider`
  - Introduced `fieldsForCreate()` in `Nova/App.php` with necessary fields
  - Ensured `sku` field has unique validation in edit mode
  - Added default values and required rules to specific fields

- fix(models): 🐛 correct foreign key in App model

  - Updated `author()` relationship in `App` model to use `user_id` instead of inferring `author_id`

- feat(policy): ✨ add create method to AppPolicy

  - Added `create()` method in `AppPolicy` allowing creation for users with Administrator role

- feat(service-provider): ✨ register AppPolicy

  - Registered `AppPolicy` explicitly in `WmPackageServiceProvider` to ensure policy application

- feat(nova): ✨ add fieldsForCreate method

  - Implemented `fieldsForCreate()` in `Nova/App.php` with required fields for app creation

- feat(validation): ✨ add unique rule to sku field

  - Added `updateRules` for `sku` field in edit mode to ensure uniqueness while ignoring the current record

- fix(fields): 🐛 add default values and required rules

  - Added default values and required rules to `default_language`, `start_end_icons_min_zoom`, and `ref_on_track_min_zoom` fields in `Nova/App.php`
