### PR TITLE
feat(oc:8014): add ImportTaxonomyThemeJob and TaxonomyTheme Nova resource

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
 | Fix import Excel POI: nomi mancanti in pois.geojson | oc:8063 | `src/Imports/Processors/EcPoiRowProcessor.php`, `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php` | Sync `properties['name']` da `getTranslations('name')` in `apply()` — replica logica observer bypassata da `saveQuietly()` |
+| ImportTaxonomyThemeJob | oc:8014 | `src/Jobs/Import/ImportTaxonomyThemeJob.php`, `src/Services/Import/GeohubImportService.php`, `config/wm-geohub-import.php` | Aggiunge il job mancante per importare TaxonomyTheme da GeoHub; registra taxonomy_theme in MODEL_IMPORT_ORDER e default_dependencies |
 | Fix getTaxonomyMorphableRecords | oc:8013 | `src/Jobs/Import/ImportTaxonomyJob.php` | Corregge il parametro passato a getTaxonomyMorphableRecords: entityId (GeoHub) invece di model->id (Maphub) |
 | Refactor SuperAdminService | oc:8006 | `src/Services/RolesAndPermissionsService.php`, `src/Support/SuperAdminService.php` (rimosso), `src/Nova/App.php`, `src/Nova/Actions/GenerateAppIconsAction.php`, `src/Nova/Actions/BuildAppPoisGeojsonAction.php`, `src/Policies/AppPolicy.php` | Sposta i check super-admin email-based in RolesAndPermissionsService; rimuove SuperAdminService |
 
@@ -16,10 +17,14 @@
 - In update mode il merge delle traduzioni è implicito: il modello caricato dal DB porta già tutte le lingue, `setTranslation` aggiorna solo la locale fornita
 - `EcTrackRowProcessor` non è affetto: non usa `setTranslation` per il nome
 
+### ImportTaxonomyThemeJob (oc:8014)
+- `Log::error()` aggiunto nel catch di `handle()` rispetto al pattern originale di `ImportTaxonomyActivityJob` — senza di esso i fallimenti appaiono come "completed" in Horizon e sono impossibili da diagnosticare
+- Campo `icon` commentato nel config `wm-geohub-import.php` con TODO: verificare con il capo se GeoHub ha la colonna `icon` in `taxonomy_themes` prima di attivarlo
+- Dopo merge: i progetti con config già pubblicato devono aggiornare manualmente `default_dependencies['app']` in `wm-geohub-import.php` oppure ri-pubblicare con `--force`
+- `taxonomy_when` e `taxonomy_target` hanno lo stesso problema (`'job' => ''`) — esclusi da questo ticket, servono ticket separati
+
 ### Fix getTaxonomyMorphableRecords (oc:8013)
 - `processDependencies()` deve passare `$this->entityId` (ID GeoHub) a `getTaxonomyMorphableRecords()`, non `$model->id` (ID Maphub locale) — i due ID sono diversi e il metodo interroga il DB GeoHub
-
-
 
 ### Refactor SuperAdminService (oc:8006)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@
 | Fix import Excel POI: nomi mancanti in pois.geojson | oc:8063 | `src/Imports/Processors/EcPoiRowProcessor.php`, `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php` | Sync `properties['name']` da `getTranslations('name')` in `apply()` — replica logica observer bypassata da `saveQuietly()` |
 | ImportTaxonomyThemeJob | oc:8014 | `src/Jobs/Import/ImportTaxonomyThemeJob.php`, `src/Services/Import/GeohubImportService.php`, `config/wm-geohub-import.php` | Aggiunge il job mancante per importare TaxonomyTheme da GeoHub; registra taxonomy_theme in MODEL_IMPORT_ORDER e default_dependencies |
 | Fix getTaxonomyMorphableRecords | oc:8013 | `src/Jobs/Import/ImportTaxonomyJob.php` | Corregge il parametro passato a getTaxonomyMorphableRecords: entityId (GeoHub) invece di model->id (Maphub) |
+| ImportTaxonomyThemeJob | oc:8014 | `src/Jobs/Import/ImportTaxonomyThemeJob.php`, `src/Services/Import/GeohubImportService.php`, `config/wm-geohub-import.php` | Aggiunge il job mancante per importare TaxonomyTheme da GeoHub; registra taxonomy_theme in MODEL_IMPORT_ORDER e default_dependencies |
 | Refactor SuperAdminService | oc:8006 | `src/Services/RolesAndPermissionsService.php`, `src/Support/SuperAdminService.php` (rimosso), `src/Nova/App.php`, `src/Nova/Actions/GenerateAppIconsAction.php`, `src/Nova/Actions/BuildAppPoisGeojsonAction.php`, `src/Policies/AppPolicy.php` | Sposta i check super-admin email-based in RolesAndPermissionsService; rimuove SuperAdminService |
 
 ## Decisioni architetturali
@@ -25,6 +26,12 @@
 
 ### Fix getTaxonomyMorphableRecords (oc:8013)
 - `processDependencies()` deve passare `$this->entityId` (ID GeoHub) a `getTaxonomyMorphableRecords()`, non `$model->id` (ID Maphub locale) — i due ID sono diversi e il metodo interroga il DB GeoHub
+
+### ImportTaxonomyThemeJob (oc:8014)
+- `Log::error()` aggiunto nel catch di `handle()` rispetto al pattern originale di `ImportTaxonomyActivityJob` — senza di esso i fallimenti appaiono come "completed" in Horizon e sono impossibili da diagnosticare
+- Campo `icon` commentato nel config `wm-geohub-import.php` con TODO: verificare con il capo se GeoHub ha la colonna `icon` in `taxonomy_themes` prima di attivarlo
+- Dopo merge: i progetti con config già pubblicato devono aggiornare manualmente `default_dependencies['app']` in `wm-geohub-import.php` oppure ri-pubblicare con `--force`
+- `taxonomy_when` e `taxonomy_target` hanno lo stesso problema (`'job' => ''`) — esclusi da questo ticket, servono ticket separati
 
 ### Refactor SuperAdminService (oc:8006)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@
 
 ### ImportTaxonomyThemeJob (oc:8014)
 - `Log::error()` aggiunto nel catch di `handle()` rispetto al pattern originale di `ImportTaxonomyActivityJob` — senza di esso i fallimenti appaiono come "completed" in Horizon e sono impossibili da diagnosticare
-- Campo `icon` commentato nel config `wm-geohub-import.php` con TODO: verificare con il capo se GeoHub ha la colonna `icon` in `taxonomy_themes` prima di attivarlo
+- Campo `icon` **attivo** nel config `wm-geohub-import.php`: GeoHub ha la colonna `icon` in `taxonomy_themes` con formato SVG, identico a `taxonomy_activity`. Il transformer `svgIconToNameIcon` è corretto.
+- `ImportTaxonomyJob::processDependencies()` usa `syncWithoutDetaching()` (non `sync()`): `sync()` azzerava tutte le associazioni del record lasciando solo l'ultimo tema importato — bug critico confermato su app 63.
 - Dopo merge: i progetti con config già pubblicato devono aggiornare manualmente `default_dependencies['app']` in `wm-geohub-import.php` oppure ri-pubblicare con `--force`
 - `taxonomy_when` e `taxonomy_target` hanno lo stesso problema (`'job' => ''`) — esclusi da questo ticket, servono ticket separati
 

--- a/config/wm-geohub-import.php
+++ b/config/wm-geohub-import.php
@@ -7,6 +7,7 @@ use Wm\WmPackage\Jobs\Import\ImportEcTrackJob;
 use Wm\WmPackage\Jobs\Import\ImportLayerJob;
 use Wm\WmPackage\Jobs\Import\ImportTaxonomyActivityJob;
 use Wm\WmPackage\Jobs\Import\ImportTaxonomyPoiTypeJob;
+use Wm\WmPackage\Jobs\Import\ImportTaxonomyThemeJob;
 use Wm\WmPackage\Services\GeometryComputationService;
 use Wm\WmPackage\Services\Import\DataTransformer;
 
@@ -153,7 +154,7 @@ return [
     |
     */
     'default_dependencies' => [
-        'app' => ['ec_poi', 'ec_track', 'taxonomy_activity', 'layer', 'ec_media'], // Import all dependencies by default
+        'app' => ['ec_poi', 'ec_track', 'taxonomy_activity', 'taxonomy_theme', 'layer', 'ec_media'],
     ],
 
     /*
@@ -628,11 +629,22 @@ return [
         */
         'taxonomy_theme' => [
             'namespace' => 'Wm\\WmPackage\\Models\\TaxonomyTheme',
-            'job' => '',
+            'job' => ImportTaxonomyThemeJob::class,
             'geohub_table' => 'taxonomy_themes',
             'identifier' => 'properties->geohub_id',
-            'fields' => [],
-            'properties' => [],
+            'fields' => [
+                'name' => ['field' => 'name', 'transformer' => [DataTransformer::class, 'jsonToArray']],
+                'description' => ['field' => 'description', 'transformer' => [DataTransformer::class, 'jsonToArray']],
+                'excerpt' => ['field' => 'excerpt', 'transformer' => [DataTransformer::class, 'jsonToArray']],
+                'identifier' => 'identifier',
+                'created_at' => 'created_at',
+                'updated_at' => 'updated_at',
+                'icon' => ['field' => 'icon', 'transformer' => [DataTransformer::class, 'svgIconToNameIcon']],
+            ],
+            'properties' => [
+                'column_name' => 'properties',
+                'mapping' => [],
+            ],
             'relations' => [
                 'morphable_table' => 'taxonomy_themeables',
                 'foreign_key' => 'taxonomy_theme_id',

--- a/database/migrations/create_taxonomy_themeables_table.php.stub
+++ b/database/migrations/create_taxonomy_themeables_table.php.stub
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        if (Schema::hasTable('taxonomy_themeables')) {
+            return;
+        }
+        Schema::create('taxonomy_themeables', function (Blueprint $table) {
+            $table->id();
+            $table->integer('taxonomy_theme_id');
+            $table->morphs('taxonomy_themeable');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('taxonomy_themeables');
+    }
+};

--- a/database/migrations/create_taxonomy_themes_table.php.stub
+++ b/database/migrations/create_taxonomy_themes_table.php.stub
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        if (Schema::hasTable('taxonomy_themes')) {
+            return;
+        }
+        Schema::create('taxonomy_themes', function (Blueprint $table) {
+            $table->id('id');
+
+            $table->text('name');
+            $table->text('description')->nullable();
+            $table->string('excerpt')->nullable();
+            $table->string('icon')->nullable();
+
+            $table->text('identifier')->nullable()->unique();
+            $table->timestamps();
+            $table->jsonb('properties')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('taxonomy_themes');
+    }
+};

--- a/database/migrations/z_add_foreign_keys_to_taxonomy_themeables_table.php.stub
+++ b/database/migrations/z_add_foreign_keys_to_taxonomy_themeables_table.php.stub
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        $existing = DB::select("SELECT constraint_name FROM information_schema.table_constraints WHERE table_name = 'taxonomy_themeables' AND constraint_type = 'FOREIGN KEY'");
+        if (! empty($existing)) {
+            return;
+        }
+        Schema::table('taxonomy_themeables', function (Blueprint $table) {
+            $table->foreign(['taxonomy_theme_id'])->references(['id'])->on('taxonomy_themes');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('taxonomy_themeables', function (Blueprint $table) {
+            $table->dropForeign('taxonomy_themeables_taxonomy_theme_id_foreign');
+        });
+    }
+};

--- a/docs/features/8014-import-taxonomy-theme-job/notes.md
+++ b/docs/features/8014-import-taxonomy-theme-job/notes.md
@@ -4,7 +4,8 @@
 
 ## Deviazioni dal piano
 
-Nessuna — implementazione non ancora iniziata.
+- **`ImportAppJob.php` non era nel piano originale:** il piano e l'overview iniziali non includevano la modifica a `ImportAppJob`. Il ticket ha segnalato esplicitamente la lacuna nella description — il blocco `if (in_array('taxonomy_theme', ...))` in `processDependencies()` e l'aggiornamento del fallback `$allDependencies` in `getAllowedDependencies()` sono stati aggiunti come fix critico. Overview e plan aggiornati di conseguenza.
+- **Rebase su `develop` necessario:** il branch `oc_8014` era stato creato prima del merge di oc:8013 (`fix: use entityId instead of model->id`). Il rebase è stato eseguito per includere il fix nella storia del branch — senza di esso `ImportTaxonomyThemeJob` avrebbe ereditato il bug di `$model->id` da `ImportTaxonomyJob`.
 
 ## Bug trovati
 
@@ -18,6 +19,6 @@ Nessuno durante la fase di analisi.
 
 ## Follow-up
 
-- Decidere con il capo se includere `icon` nel mapping fields (verificare esistenza colonna in GeoHub).
+- ~~Decidere con il capo se includere `icon`~~ — confermato: GeoHub ha la colonna `icon` in `taxonomy_themes` con formato SVG. Il transformer `svgIconToNameIcon` è attivo nel config.
 - Aprire ticket separati per `ImportTaxonomyWhenJob` e `ImportTaxonomyTargetJob` — stessa lacuna, esclusi dallo scope di questo ticket.
 - Dopo il merge, comunicare ai dev dei progetti che usano wm-package di aggiornare il config pubblicato (`default_dependencies` per `app`).

--- a/docs/features/8014-import-taxonomy-theme-job/notes.md
+++ b/docs/features/8014-import-taxonomy-theme-job/notes.md
@@ -21,13 +21,62 @@ Nessuno durante la fase di analisi.
 
 - **`Log::error()` nel catch:** aggiunto rispetto al pattern originale di `ImportTaxonomyActivityJob` (che inghiotte silenziosamente). Motivazione: la Challenge adversariale ha evidenziato che senza logging un fallimento completo del job appare come "completed" in Horizon, rendendo il debug impossibile.
 - **Campo `icon` abilitato nel config:** GeoHub ha la colonna `icon` in `taxonomy_themes` con formato SVG, identico a `taxonomy_activity`. Il transformer `svgIconToNameIcon` è corretto.
-- **`identifier` mappato come `'identifier' => 'identifier'`** (stile taxonomy_activity) e non come `'identifier' => 'properties->geohub_id'` (stile taxonomy_when): il config top-level ha già `'identifier' => 'properties->geohub_id'` per il lookup, il campo `fields.identifier` mappa la colonna GeoHub `identifier` al campo locale. Da verificare al primo test che il dato arrivi correttamente.
+- **`identifier` mappato come `'identifier' => 'identifier'`** (stile taxonomy_activity) e non come `'identifier' => 'properties->geohub_id'` (stile taxonomy_when): il config top-level ha già `'identifier' => 'properties->geohub_id'` per il lookup, il campo `fields.identifier` mappa la colonna GeoHub `identifier` al campo locale. Verificato al test E2E post-fix.
 
-## Follow-up
+## Test E2E post-fix sync (16-06-2026, app GeoHub 63, DB ripristinato)
+
+Ambiente: maphub locale branch `oc_8014`, GeoHub dev via tunnel SSH `dev.geohub`.
+
+### Comandi eseguiti
+
+```bash
+docker exec php-maphub php artisan wm:import-from-geohub app 63
+# dopo primo passaggio (pivot a 0 per race condition):
+docker exec php-maphub php artisan wm:import-from-geohub app 63 --dependencies=taxonomy_theme
+```
+
+### Esito verifiche
+
+| Check | Esito | Note |
+| ----- | ----- | ---- |
+| Connessione GeoHub app 63 | PASS | Tunnel SSH richiesto |
+| ImportAppJob / app locale | PASS | `id=3`, `geohub_id=63` |
+| ImportTaxonomyThemeJob | PASS | 502/502 themes, 0 errori job |
+| Fix `syncWithoutDetaching` multi-theme | PASS | Vedi casi sotto |
+| Pivot totali allineati a GeoHub | PASS | Dopo re-import taxonomy |
+| API filtro tema (webapp) | PASS | 2 features su theme 365 |
+| Nova TaxonomyTheme | PASS | Risorsa registrata |
+
+### Fix sync — casi noti (dopo re-import taxonomy)
+
+| Entità | GeoHub id | Locale id | Theme GH | Theme locale | GH theme ids |
+| ------ | --------- | --------- | -------- | ------------ | ------------ |
+| EcTrack *Sentiero Marcò* | 82756 | 41 | 3 | **3** | 366, 367, 369 |
+| EcPoi *Laghetto Welsperg* | 38201 | 99 | 3 | **3** | 364, 389, 390 |
+
+### Pivot totali (app 63, post re-import)
+
+| Tipo | Contenuti GH/local | Pivot GH/local | Multi-entity GH/local |
+| ---- | ------------------ | -------------- | --------------------- |
+| EcTrack | 22/22 | **25/25** | 5/5 |
+| EcPoi | 119/119 | **182/182** | 62/62 |
+| Layer | 9/9 | **9/9** | — |
+| **Totale pivot** | | **216** | |
+
+Confronto test pre-fix: stessi casi avevano 1/3 theme (track 82756) e 1/3 (POI 38201); pivot POI 119/182.
+
+### Race condition
+
+Al **primo** import completo: 502 themes importati ma **0 pivot** (`taxonomy_themeables` vuota) perché i job `ImportTaxonomyThemeJob` girano in parallelo con `ImportEcTrackJob`/`ImportEcPoiJob`. Il re-import `--dependencies=taxonomy_theme` risolve tutto (pivot 216/216 allineati a GeoHub).
+
+### Verdetto
+
+**OK per merge** — il fix `syncWithoutDetaching()` è confermato: associazioni multiple replicate correttamente. Resta come limite noto la race condition al primo passaggio (workaround: re-import taxonomy o ticket follow-up per serializzare taxonomy dopo EC).
 
 - ~~Decidere con il capo se includere `icon`~~ — confermato: GeoHub ha la colonna `icon` in `taxonomy_themes` con formato SVG. Il transformer `svgIconToNameIcon` è attivo nel config.
 - Aprire ticket separati per `ImportTaxonomyWhenJob` e `ImportTaxonomyTargetJob` — stessa lacuna, esclusi dallo scope di questo ticket.
 - Dopo il merge, comunicare ai dev dei progetti che usano wm-package di aggiornare il config pubblicato (`default_dependencies` per `app`).
+- **Race condition taxonomy vs EC:** al primo import i pivot restano vuoti finché non si re-importa `taxonomy_theme`. Valutare ticket per accodare taxonomy dopo `ec_track`/`ec_poi` o job di retry associazioni a fine batch.
 
 > Ticket: oc:8014
 

--- a/docs/features/8014-import-taxonomy-theme-job/notes.md
+++ b/docs/features/8014-import-taxonomy-theme-job/notes.md
@@ -22,3 +22,27 @@ Nessuno durante la fase di analisi.
 - ~~Decidere con il capo se includere `icon`~~ — confermato: GeoHub ha la colonna `icon` in `taxonomy_themes` con formato SVG. Il transformer `svgIconToNameIcon` è attivo nel config.
 - Aprire ticket separati per `ImportTaxonomyWhenJob` e `ImportTaxonomyTargetJob` — stessa lacuna, esclusi dallo scope di questo ticket.
 - Dopo il merge, comunicare ai dev dei progetti che usano wm-package di aggiornare il config pubblicato (`default_dependencies` per `app`).
+
+> Ticket: oc:8014
+
+# Notes — ImportTaxonomyThemeJob
+
+## Deviazioni dal piano
+
+Nessuna — implementazione non ancora iniziata.
+
+## Bug trovati
+
+Nessuno durante la fase di analisi.
+
+## Decisioni
+
+- **`Log::error()` nel catch:** aggiunto rispetto al pattern originale di `ImportTaxonomyActivityJob` (che inghiotte silenziosamente). Motivazione: la Challenge adversariale ha evidenziato che senza logging un fallimento completo del job appare come "completed" in Horizon, rendendo il debug impossibile.
+- **Campo `icon` abilitato nel config:** GeoHub ha la colonna `icon` in `taxonomy_themes` con formato SVG, identico a `taxonomy_activity`. Il transformer `svgIconToNameIcon` è corretto.
+- **`identifier` mappato come `'identifier' => 'identifier'`** (stile taxonomy_activity) e non come `'identifier' => 'properties->geohub_id'` (stile taxonomy_when): il config top-level ha già `'identifier' => 'properties->geohub_id'` per il lookup, il campo `fields.identifier` mappa la colonna GeoHub `identifier` al campo locale. Da verificare al primo test che il dato arrivi correttamente.
+
+## Follow-up
+
+- Decidere con il capo se includere `icon` nel mapping fields (verificare esistenza colonna in GeoHub).
+- Aprire ticket separati per `ImportTaxonomyWhenJob` e `ImportTaxonomyTargetJob` — stessa lacuna, esclusi dallo scope di questo ticket.
+- Dopo il merge, comunicare ai dev dei progetti che usano wm-package di aggiornare il config pubblicato (`default_dependencies` per `app`).

--- a/docs/features/8014-import-taxonomy-theme-job/notes.md
+++ b/docs/features/8014-import-taxonomy-theme-job/notes.md
@@ -2,6 +2,12 @@
 
 # Notes — ImportTaxonomyThemeJob
 
+## Fix da review (Rubens Garofalo, 16-06-2026)
+
+- **`sync()` → `syncWithoutDetaching()` in `ImportTaxonomyJob`:** bloccante. `sync()` sovrascriveva tutte le associazioni del record con l'ultimo tema importato; ogni job azzerava i temi precedenti. Confermato su app 63: EcTrack 82756 e EcPoi 38201 con 3 temi ciascuno — ne rimaneva 1 dopo l'import. Fix: `syncWithoutDetaching()` in `processDependencies()`.
+- **Rimosso dead code `$syncData`:** il loop che costruiva `$syncData` era unreachable (il dato veniva ricostruito inline nel loop successivo). Rimosso per chiarezza.
+- **Nota `icon` in CLAUDE.md aggiornata:** la decisione di attivare il campo `icon` era stata presa e registrata in notes.md, ma CLAUDE.md riportava ancora la nota "commentato/TBD". Allineato.
+
 ## Deviazioni dal piano
 
 - **`ImportAppJob.php` non era nel piano originale:** il piano e l'overview iniziali non includevano la modifica a `ImportAppJob`. Il ticket ha segnalato esplicitamente la lacuna nella description — il blocco `if (in_array('taxonomy_theme', ...))` in `processDependencies()` e l'aggiornamento del fallback `$allDependencies` in `getAllowedDependencies()` sono stati aggiunti come fix critico. Overview e plan aggiornati di conseguenza.

--- a/docs/features/8014-import-taxonomy-theme-job/notes.md
+++ b/docs/features/8014-import-taxonomy-theme-job/notes.md
@@ -1,0 +1,23 @@
+> Ticket: oc:8014
+
+# Notes — ImportTaxonomyThemeJob
+
+## Deviazioni dal piano
+
+Nessuna — implementazione non ancora iniziata.
+
+## Bug trovati
+
+Nessuno durante la fase di analisi.
+
+## Decisioni
+
+- **`Log::error()` nel catch:** aggiunto rispetto al pattern originale di `ImportTaxonomyActivityJob` (che inghiotte silenziosamente). Motivazione: la Challenge adversariale ha evidenziato che senza logging un fallimento completo del job appare come "completed" in Horizon, rendendo il debug impossibile.
+- **Campo `icon` abilitato nel config:** GeoHub ha la colonna `icon` in `taxonomy_themes` con formato SVG, identico a `taxonomy_activity`. Il transformer `svgIconToNameIcon` è corretto.
+- **`identifier` mappato come `'identifier' => 'identifier'`** (stile taxonomy_activity) e non come `'identifier' => 'properties->geohub_id'` (stile taxonomy_when): il config top-level ha già `'identifier' => 'properties->geohub_id'` per il lookup, il campo `fields.identifier` mappa la colonna GeoHub `identifier` al campo locale. Da verificare al primo test che il dato arrivi correttamente.
+
+## Follow-up
+
+- Decidere con il capo se includere `icon` nel mapping fields (verificare esistenza colonna in GeoHub).
+- Aprire ticket separati per `ImportTaxonomyWhenJob` e `ImportTaxonomyTargetJob` — stessa lacuna, esclusi dallo scope di questo ticket.
+- Dopo il merge, comunicare ai dev dei progetti che usano wm-package di aggiornare il config pubblicato (`default_dependencies` per `app`).

--- a/docs/features/8014-import-taxonomy-theme-job/overview.md
+++ b/docs/features/8014-import-taxonomy-theme-job/overview.md
@@ -6,6 +6,8 @@
 
 Il sistema acquisirà la capacità di importare i `TaxonomyTheme` da GeoHub durante l'import completo di un'app. Attualmente il job mancava e la taxonomy Theme non veniva mai importata, rendendo non funzionanti i filtri per tema nelle app.
 
+**Aggiornamento (fix critico):** anche dopo la creazione di `ImportTaxonomyThemeJob`, l'import non funzionava perché `ImportAppJob::processDependencies()` usa blocchi `if` espliciti per ogni dipendenza — il blocco per `taxonomy_theme` era assente. Il job veniva ignorato anche quando presente nel config.
+
 ## Perché
 
 Le app GeoHub che usano filtri per tema non vengono importate correttamente su Maphub perché il job `ImportTaxonomyThemeJob` non esiste. Il modello `TaxonomyTheme` e la configurazione in `wm-geohub-import.php` esistono già, mancano solo il job e la sua registrazione.
@@ -22,6 +24,8 @@ Le app GeoHub che usano filtri per tema non vengono importate correttamente su M
 - [ ] Aggiungere `taxonomy_theme` a `default_dependencies['app']` in `wm-geohub-import.php`
 - [ ] Popolare `'job'` per `taxonomy_theme` in `wm-geohub-import.php` con `ImportTaxonomyThemeJob::class`
 - [ ] Popolare `'fields'` per `taxonomy_theme` in `wm-geohub-import.php` con: `name`, `description`, `excerpt`, `identifier`, `created_at`, `updated_at`, `icon` (allineato al pattern `taxonomy_activity`)
+- [ ] Aggiungere blocco `if (in_array('taxonomy_theme', $allowedDependencies))` in `ImportAppJob::processDependencies()`, dopo `taxonomy_poi_types` e prima di `ec_poi` (ordine: tutti i taxonomy prima delle entità EC)
+- [ ] Aggiungere `taxonomy_theme` a `$allDependencies` in `ImportAppJob::getAllowedDependencies()` per allineare il fallback hardcoded al config
 
 ## Rischi
 
@@ -29,6 +33,7 @@ Le app GeoHub che usano filtri per tema non vengono importate correttamente su M
 - **Campo `icon` da verificare con il capo (decisione pendente):** non è confermato che GeoHub abbia la colonna `icon` nella tabella `taxonomy_themes`. Se manca o ha formato diverso, il transformer `svgIconToNameIcon` genera un'eccezione inghiottita silenziosamente: i job appaiono completati in Horizon ma i theme non vengono importati. Chiedere conferma prima di includere `icon` nel mapping `fields`.
 - **Eccezioni silenziose:** il try/catch non logga gli errori — aggiungere `Log::error()` nel catch per rendere i fallimenti visibili nei log senza far fallire il job.
 - **Tabella `taxonomy_themes` locale:** verificare che le migrazioni del wm-package siano state pubblicate ed eseguite nel progetto target prima del test.
+- **`ImportAppJob` non dinamico:** `getAllowedDependencies()` usa un array hardcoded come fallback — aggiungendo `taxonomy_theme` al fallback e al blocco `if`, si chiude il flusso. Se in futuro si aggiungono nuove taxonomy, lo stesso pattern va ripetuto manualmente.
 
 ## Out of scope
 
@@ -45,6 +50,7 @@ Repo **`wm-package`**:
 | `src/Nova/TaxonomyTheme.php` | Nuovo file — Nova resource |
 | `src/Services/Import/GeohubImportService.php` | Aggiunta di `taxonomy_theme` in `MODEL_IMPORT_ORDER` |
 | `config/wm-geohub-import.php` | `job`, `fields`, `default_dependencies` per `taxonomy_theme` |
+| `src/Jobs/Import/ImportAppJob.php` | Aggiunta `taxonomy_theme` in `processDependencies()` e `getAllowedDependencies()` |
 
 Repo **`maphub`** (boilerplate):
 

--- a/docs/features/8014-import-taxonomy-theme-job/overview.md
+++ b/docs/features/8014-import-taxonomy-theme-job/overview.md
@@ -1,0 +1,54 @@
+> Ticket: oc:8014
+
+# Feature: aggiungere ImportTaxonomyThemeJob e registrarlo nell'import order
+
+## Cosa cambia
+
+Il sistema acquisirà la capacità di importare i `TaxonomyTheme` da GeoHub durante l'import completo di un'app. Attualmente il job mancava e la taxonomy Theme non veniva mai importata, rendendo non funzionanti i filtri per tema nelle app.
+
+## Perché
+
+Le app GeoHub che usano filtri per tema non vengono importate correttamente su Maphub perché il job `ImportTaxonomyThemeJob` non esiste. Il modello `TaxonomyTheme` e la configurazione in `wm-geohub-import.php` esistono già, mancano solo il job e la sua registrazione.
+
+## Requisiti
+
+- [ ] Creare `ImportTaxonomyThemeJob` sul pattern di `ImportTaxonomyActivityJob`
+  - `getModelKey()` → `'taxonomy_theme'`
+  - `getForeignKey()` → `'taxonomy_theme_id'`
+  - `getRelationshipName()` → `'taxonomyThemes'`
+  - Timeout: 300 secondi (5 minuti)
+  - Gestione errori silenziosa: try/catch in `handle()` che non rilancia l'eccezione
+- [ ] Registrare `taxonomy_theme` in `MODEL_IMPORT_ORDER` in `GeohubImportService`, dopo `taxonomy_activity` e prima di `ec_poi`
+- [ ] Aggiungere `taxonomy_theme` a `default_dependencies['app']` in `wm-geohub-import.php`
+- [ ] Popolare `'job'` per `taxonomy_theme` in `wm-geohub-import.php` con `ImportTaxonomyThemeJob::class`
+- [ ] Popolare `'fields'` per `taxonomy_theme` in `wm-geohub-import.php` con: `name`, `description`, `excerpt`, `identifier`, `created_at`, `updated_at`, `icon` (allineato al pattern `taxonomy_activity`)
+
+## Rischi
+
+- **Accesso GeoHub:** per eseguire e testare è necessario che il proprio IP sia abilitato dal firewall GeoHub — il test in locale non è possibile senza whitelist.
+- **Campo `icon` da verificare con il capo (decisione pendente):** non è confermato che GeoHub abbia la colonna `icon` nella tabella `taxonomy_themes`. Se manca o ha formato diverso, il transformer `svgIconToNameIcon` genera un'eccezione inghiottita silenziosamente: i job appaiono completati in Horizon ma i theme non vengono importati. Chiedere conferma prima di includere `icon` nel mapping `fields`.
+- **Eccezioni silenziose:** il try/catch non logga gli errori — aggiungere `Log::error()` nel catch per rendere i fallimenti visibili nei log senza far fallire il job.
+- **Tabella `taxonomy_themes` locale:** verificare che le migrazioni del wm-package siano state pubblicate ed eseguite nel progetto target prima del test.
+
+## Out of scope
+
+- `ImportTaxonomyWhenJob` e `ImportTaxonomyTargetJob` — hanno lo stesso problema (`'job' => ''`) ma sono esclusi da questo ciclo; ticket separati da aprire.
+- Eventuali Nova actions o UI per la gestione dei TaxonomyTheme.
+
+## Moduli toccati
+
+Repo **`wm-package`**:
+
+| File | Modifica |
+|---|---|
+| `src/Jobs/Import/ImportTaxonomyThemeJob.php` | Nuovo file |
+| `src/Nova/TaxonomyTheme.php` | Nuovo file — Nova resource |
+| `src/Services/Import/GeohubImportService.php` | Aggiunta di `taxonomy_theme` in `MODEL_IMPORT_ORDER` |
+| `config/wm-geohub-import.php` | `job`, `fields`, `default_dependencies` per `taxonomy_theme` |
+
+Repo **`maphub`** (boilerplate):
+
+| File | Modifica |
+|---|---|
+| `app/Nova/TaxonomyTheme.php` | Nuovo file — stub che estende wm-package |
+| `app/Providers/NovaServiceProvider.php` | Aggiunta di `TaxonomyTheme` nel menu Taxonomies |

--- a/docs/features/8014-import-taxonomy-theme-job/overview.md
+++ b/docs/features/8014-import-taxonomy-theme-job/overview.md
@@ -58,3 +58,58 @@ Repo **`maphub`** (boilerplate):
 |---|---|
 | `app/Nova/TaxonomyTheme.php` | Nuovo file — stub che estende wm-package |
 | `app/Providers/NovaServiceProvider.php` | Aggiunta di `TaxonomyTheme` nel menu Taxonomies |
+
+> Ticket: oc:8014
+
+# Feature: aggiungere ImportTaxonomyThemeJob e registrarlo nell'import order
+
+## Cosa cambia
+
+Il sistema acquisirà la capacità di importare i `TaxonomyTheme` da GeoHub durante l'import completo di un'app. Attualmente il job mancava e la taxonomy Theme non veniva mai importata, rendendo non funzionanti i filtri per tema nelle app.
+
+## Perché
+
+Le app GeoHub che usano filtri per tema non vengono importate correttamente su Maphub perché il job `ImportTaxonomyThemeJob` non esiste. Il modello `TaxonomyTheme` e la configurazione in `wm-geohub-import.php` esistono già, mancano solo il job e la sua registrazione.
+
+## Requisiti
+
+- [ ] Creare `ImportTaxonomyThemeJob` sul pattern di `ImportTaxonomyActivityJob`
+  - `getModelKey()` → `'taxonomy_theme'`
+  - `getForeignKey()` → `'taxonomy_theme_id'`
+  - `getRelationshipName()` → `'taxonomyThemes'`
+  - Timeout: 300 secondi (5 minuti)
+  - Gestione errori silenziosa: try/catch in `handle()` che non rilancia l'eccezione
+- [ ] Registrare `taxonomy_theme` in `MODEL_IMPORT_ORDER` in `GeohubImportService`, dopo `taxonomy_activity` e prima di `ec_poi`
+- [ ] Aggiungere `taxonomy_theme` a `default_dependencies['app']` in `wm-geohub-import.php`
+- [ ] Popolare `'job'` per `taxonomy_theme` in `wm-geohub-import.php` con `ImportTaxonomyThemeJob::class`
+- [ ] Popolare `'fields'` per `taxonomy_theme` in `wm-geohub-import.php` con: `name`, `description`, `excerpt`, `identifier`, `created_at`, `updated_at`, `icon` (allineato al pattern `taxonomy_activity`)
+
+## Rischi
+
+- **Accesso GeoHub:** per eseguire e testare è necessario che il proprio IP sia abilitato dal firewall GeoHub — il test in locale non è possibile senza whitelist.
+- **Campo `icon` da verificare con il capo (decisione pendente):** non è confermato che GeoHub abbia la colonna `icon` nella tabella `taxonomy_themes`. Se manca o ha formato diverso, il transformer `svgIconToNameIcon` genera un'eccezione inghiottita silenziosamente: i job appaiono completati in Horizon ma i theme non vengono importati. Chiedere conferma prima di includere `icon` nel mapping `fields`.
+- **Eccezioni silenziose:** il try/catch non logga gli errori — aggiungere `Log::error()` nel catch per rendere i fallimenti visibili nei log senza far fallire il job.
+- **Tabella `taxonomy_themes` locale:** verificare che le migrazioni del wm-package siano state pubblicate ed eseguite nel progetto target prima del test.
+
+## Out of scope
+
+- `ImportTaxonomyWhenJob` e `ImportTaxonomyTargetJob` — hanno lo stesso problema (`'job' => ''`) ma sono esclusi da questo ciclo; ticket separati da aprire.
+- Eventuali Nova actions o UI per la gestione dei TaxonomyTheme.
+
+## Moduli toccati
+
+Repo **`wm-package`**:
+
+| File | Modifica |
+|---|---|
+| `src/Jobs/Import/ImportTaxonomyThemeJob.php` | Nuovo file |
+| `src/Nova/TaxonomyTheme.php` | Nuovo file — Nova resource |
+| `src/Services/Import/GeohubImportService.php` | Aggiunta di `taxonomy_theme` in `MODEL_IMPORT_ORDER` |
+| `config/wm-geohub-import.php` | `job`, `fields`, `default_dependencies` per `taxonomy_theme` |
+
+Repo **`maphub`** (boilerplate):
+
+| File | Modifica |
+|---|---|
+| `app/Nova/TaxonomyTheme.php` | Nuovo file — stub che estende wm-package |
+| `app/Providers/NovaServiceProvider.php` | Aggiunta di `TaxonomyTheme` nel menu Taxonomies |

--- a/docs/features/8014-import-taxonomy-theme-job/plan.md
+++ b/docs/features/8014-import-taxonomy-theme-job/plan.md
@@ -238,3 +238,222 @@ Apri PR da `feature/oc-8014-import-taxonomy-theme-job` verso `develop` in `wm-pa
 Apri PR da `feature/oc-8014-import-taxonomy-theme-job` verso `develop` in `maphub`.
 
 Descrizione PR: richiama i rischi noti (icon da decidere, config pubblicato da aggiornare nei progetti).
+
+> Ticket: oc:8014
+
+# Plan — ImportTaxonomyThemeJob
+
+## Repo coinvolto
+
+Tutto il codice va in **`wm-package`**. Il repo principale `maphub` non viene toccato.
+
+---
+
+## Step 1 — Crea il branch
+
+```bash
+cd wm-package
+git checkout -b feature/oc-8014-import-taxonomy-theme-job
+```
+
+---
+
+## Step 2 — Crea `ImportTaxonomyThemeJob`
+
+**File:** `wm-package/src/Jobs/Import/ImportTaxonomyThemeJob.php`
+
+Modella il file su `ImportTaxonomyActivityJob`. Differenze rispetto al pattern:
+- `getModelKey()` → `'taxonomy_theme'`
+- `getForeignKey()` → `'taxonomy_theme_id'`
+- `getRelationshipName()` → `'taxonomyThemes'`
+- Nel catch di `handle()` aggiungere `Log::error()` per rendere i fallimenti visibili nei log senza far fallire il job (mitigazione rilevata in Challenge)
+
+```php
+<?php
+
+namespace Wm\WmPackage\Jobs\Import;
+
+use Illuminate\Support\Facades\Log;
+use Wm\WmPackage\Services\Import\GeohubImportService;
+
+class ImportTaxonomyThemeJob extends ImportTaxonomyJob
+{
+    public $timeout = 300;
+
+    public function getModelKey(): string
+    {
+        return parent::getModelKey().'theme';
+    }
+
+    protected function getForeignKey(): string
+    {
+        return 'taxonomy_theme_id';
+    }
+
+    protected function getRelationshipName(): string
+    {
+        return 'taxonomyThemes';
+    }
+
+    public function handle(GeohubImportService $importService): void
+    {
+        try {
+            parent::handle($importService);
+        } catch (\Exception $e) {
+            Log::error('ImportTaxonomyThemeJob failed: '.$e->getMessage(), [
+                'entity_id' => $this->entityId ?? null,
+            ]);
+        }
+    }
+}
+```
+
+---
+
+## Step 3 — Aggiorna `GeohubImportService`
+
+**File:** `wm-package/src/Services/Import/GeohubImportService.php`
+
+Aggiungere `'taxonomy_theme'` in `MODEL_IMPORT_ORDER` dopo `taxonomy_activity` e prima di `ec_poi`:
+
+```php
+protected const MODEL_IMPORT_ORDER = [
+    'app',
+    'taxonomy_activity',
+    'taxonomy_theme',   // ← aggiunto
+    'taxonomy_poi_types',
+    'ec_poi',
+    'ec_track',
+    'layer',
+    'ec_media',
+];
+```
+
+---
+
+## Step 4 — Aggiorna `wm-geohub-import.php`
+
+**File:** `wm-package/config/wm-geohub-import.php`
+
+### 4a — Aggiunge `ImportTaxonomyThemeJob` all'use in cima al file
+
+Verificare che l'import della classe sia presente tra gli `use` in testa al file (stesso pattern degli altri job).
+
+### 4b — Popola `'job'` per `taxonomy_theme`
+
+```php
+'taxonomy_theme' => [
+    // ...
+    'job' => ImportTaxonomyThemeJob::class,
+    // ...
+```
+
+### 4c — Popola `'fields'` per `taxonomy_theme`
+
+```php
+'fields' => [
+    'name'        => ['field' => 'name',        'transformer' => [DataTransformer::class, 'jsonToArray']],
+    'description' => ['field' => 'description', 'transformer' => [DataTransformer::class, 'jsonToArray']],
+    'excerpt'     => ['field' => 'excerpt',     'transformer' => [DataTransformer::class, 'jsonToArray']],
+    'identifier'  => 'identifier',
+    'created_at'  => 'created_at',
+    'updated_at'  => 'updated_at',
+    // 'icon' => ['field' => 'icon', 'transformer' => [DataTransformer::class, 'svgIconToNameIcon']],
+    // ↑ DA DECIDERE: verificare con il capo se GeoHub ha la colonna `icon` in taxonomy_themes
+    //   e se il formato è SVG (come taxonomy_activity) prima di decommentare.
+],
+```
+
+### 4d — Aggiunge `taxonomy_theme` a `default_dependencies`
+
+```php
+'default_dependencies' => [
+    'app' => ['ec_poi', 'ec_track', 'taxonomy_activity', 'taxonomy_theme', 'layer', 'ec_media'],
+],
+```
+
+---
+
+## Step 5 — Verifica pre-test
+
+Prima di testare su un ambiente con GeoHub accessibile:
+
+- [ ] Verificare che la migrazione per `taxonomy_themes` sia pubblicata ed eseguita nel progetto target (`php artisan migrate:status | grep taxonomy_theme`)
+- [ ] Assicurarsi che il proprio IP sia nella whitelist del firewall GeoHub
+- [ ] Dopo il merge nel package, i progetti che hanno già pubblicato `wm-geohub-import.php` devono aggiornare manualmente `default_dependencies` oppure ri-pubblicare il config con `php artisan vendor:publish --tag=wm-package-config --force`
+
+---
+
+## Step 6 — Commit
+
+```
+feat(oc:8014): add ImportTaxonomyThemeJob and register in import order
+```
+
+Include tutti e tre i file modificati: job, service, config.
+
+---
+
+## Step 5b — Crea `TaxonomyTheme` Nova resource in wm-package
+
+**File:** `wm-package/src/Nova/TaxonomyTheme.php`
+
+Segue il pattern di `TaxonomyActivity`:
+
+```php
+<?php
+
+namespace Wm\WmPackage\Nova;
+
+use Laravel\Nova\Fields\MorphToMany;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class TaxonomyTheme extends AbstractTaxonomyResource
+{
+    public static $model = \Wm\WmPackage\Models\TaxonomyTheme::class;
+
+    public static $title = 'name';
+
+    public function fields(NovaRequest $request): array
+    {
+        return [
+            ...parent::fields($request),
+            MorphToMany::make('Tracks Associate', 'ecTracks', EcTrack::class)
+                ->display('name'),
+        ];
+    }
+}
+```
+
+---
+
+## Step 5c — Crea stub `TaxonomyTheme` in maphub
+
+**File:** `maphub/app/Nova/TaxonomyTheme.php`
+
+```php
+<?php
+
+namespace App\Nova;
+
+use Wm\WmPackage\Nova\TaxonomyTheme as WmTaxonomyTheme;
+
+class TaxonomyTheme extends WmTaxonomyTheme {}
+```
+
+---
+
+## Step 5d — Registra `TaxonomyTheme` nel menu Nova di maphub
+
+**File:** `maphub/app/Providers/NovaServiceProvider.php`
+
+Aggiungere `use App\Nova\TaxonomyTheme;` tra gli import e `MenuItem::resource(TaxonomyTheme::class)` nella sezione `Taxonomies`.
+
+---
+
+## Step 7 — PR
+
+Apri PR da `feature/oc-8014-import-taxonomy-theme-job` verso `develop` in `wm-package`.
+Apri PR da `feature/oc-8014-import-taxonomy-theme-job` verso `develop` in `maphub`.
+
+Descrizione PR: richiama i rischi noti (icon da decidere, config pubblicato da aggiornare nei progetti).

--- a/docs/features/8014-import-taxonomy-theme-job/plan.md
+++ b/docs/features/8014-import-taxonomy-theme-job/plan.md
@@ -1,0 +1,218 @@
+> Ticket: oc:8014
+
+# Plan — ImportTaxonomyThemeJob
+
+## Repo coinvolto
+
+Tutto il codice va in **`wm-package`**. Il repo principale `maphub` non viene toccato.
+
+---
+
+## Step 1 — Crea il branch
+
+```bash
+cd wm-package
+git checkout -b feature/oc-8014-import-taxonomy-theme-job
+```
+
+---
+
+## Step 2 — Crea `ImportTaxonomyThemeJob`
+
+**File:** `wm-package/src/Jobs/Import/ImportTaxonomyThemeJob.php`
+
+Modella il file su `ImportTaxonomyActivityJob`. Differenze rispetto al pattern:
+- `getModelKey()` → `'taxonomy_theme'`
+- `getForeignKey()` → `'taxonomy_theme_id'`
+- `getRelationshipName()` → `'taxonomyThemes'`
+- Nel catch di `handle()` aggiungere `Log::error()` per rendere i fallimenti visibili nei log senza far fallire il job (mitigazione rilevata in Challenge)
+
+```php
+<?php
+
+namespace Wm\WmPackage\Jobs\Import;
+
+use Illuminate\Support\Facades\Log;
+use Wm\WmPackage\Services\Import\GeohubImportService;
+
+class ImportTaxonomyThemeJob extends ImportTaxonomyJob
+{
+    public $timeout = 300;
+
+    public function getModelKey(): string
+    {
+        return parent::getModelKey().'theme';
+    }
+
+    protected function getForeignKey(): string
+    {
+        return 'taxonomy_theme_id';
+    }
+
+    protected function getRelationshipName(): string
+    {
+        return 'taxonomyThemes';
+    }
+
+    public function handle(GeohubImportService $importService): void
+    {
+        try {
+            parent::handle($importService);
+        } catch (\Exception $e) {
+            Log::error('ImportTaxonomyThemeJob failed: '.$e->getMessage(), [
+                'entity_id' => $this->entityId ?? null,
+            ]);
+        }
+    }
+}
+```
+
+---
+
+## Step 3 — Aggiorna `GeohubImportService`
+
+**File:** `wm-package/src/Services/Import/GeohubImportService.php`
+
+Aggiungere `'taxonomy_theme'` in `MODEL_IMPORT_ORDER` dopo `taxonomy_activity` e prima di `ec_poi`:
+
+```php
+protected const MODEL_IMPORT_ORDER = [
+    'app',
+    'taxonomy_activity',
+    'taxonomy_theme',   // ← aggiunto
+    'taxonomy_poi_types',
+    'ec_poi',
+    'ec_track',
+    'layer',
+    'ec_media',
+];
+```
+
+---
+
+## Step 4 — Aggiorna `wm-geohub-import.php`
+
+**File:** `wm-package/config/wm-geohub-import.php`
+
+### 4a — Aggiunge `ImportTaxonomyThemeJob` all'use in cima al file
+
+Verificare che l'import della classe sia presente tra gli `use` in testa al file (stesso pattern degli altri job).
+
+### 4b — Popola `'job'` per `taxonomy_theme`
+
+```php
+'taxonomy_theme' => [
+    // ...
+    'job' => ImportTaxonomyThemeJob::class,
+    // ...
+```
+
+### 4c — Popola `'fields'` per `taxonomy_theme`
+
+```php
+'fields' => [
+    'name'        => ['field' => 'name',        'transformer' => [DataTransformer::class, 'jsonToArray']],
+    'description' => ['field' => 'description', 'transformer' => [DataTransformer::class, 'jsonToArray']],
+    'excerpt'     => ['field' => 'excerpt',     'transformer' => [DataTransformer::class, 'jsonToArray']],
+    'identifier'  => 'identifier',
+    'created_at'  => 'created_at',
+    'updated_at'  => 'updated_at',
+    // 'icon' => ['field' => 'icon', 'transformer' => [DataTransformer::class, 'svgIconToNameIcon']],
+    // ↑ DA DECIDERE: verificare con il capo se GeoHub ha la colonna `icon` in taxonomy_themes
+    //   e se il formato è SVG (come taxonomy_activity) prima di decommentare.
+],
+```
+
+### 4d — Aggiunge `taxonomy_theme` a `default_dependencies`
+
+```php
+'default_dependencies' => [
+    'app' => ['ec_poi', 'ec_track', 'taxonomy_activity', 'taxonomy_theme', 'layer', 'ec_media'],
+],
+```
+
+---
+
+## Step 5 — Verifica pre-test
+
+Prima di testare su un ambiente con GeoHub accessibile:
+
+- [ ] Verificare che la migrazione per `taxonomy_themes` sia pubblicata ed eseguita nel progetto target (`php artisan migrate:status | grep taxonomy_theme`)
+- [ ] Assicurarsi che il proprio IP sia nella whitelist del firewall GeoHub
+- [ ] Dopo il merge nel package, i progetti che hanno già pubblicato `wm-geohub-import.php` devono aggiornare manualmente `default_dependencies` oppure ri-pubblicare il config con `php artisan vendor:publish --tag=wm-package-config --force`
+
+---
+
+## Step 6 — Commit
+
+```
+feat(oc:8014): add ImportTaxonomyThemeJob and register in import order
+```
+
+Include tutti e tre i file modificati: job, service, config.
+
+---
+
+## Step 5b — Crea `TaxonomyTheme` Nova resource in wm-package
+
+**File:** `wm-package/src/Nova/TaxonomyTheme.php`
+
+Segue il pattern di `TaxonomyActivity`:
+
+```php
+<?php
+
+namespace Wm\WmPackage\Nova;
+
+use Laravel\Nova\Fields\MorphToMany;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class TaxonomyTheme extends AbstractTaxonomyResource
+{
+    public static $model = \Wm\WmPackage\Models\TaxonomyTheme::class;
+
+    public static $title = 'name';
+
+    public function fields(NovaRequest $request): array
+    {
+        return [
+            ...parent::fields($request),
+            MorphToMany::make('Tracks Associate', 'ecTracks', EcTrack::class)
+                ->display('name'),
+        ];
+    }
+}
+```
+
+---
+
+## Step 5c — Crea stub `TaxonomyTheme` in maphub
+
+**File:** `maphub/app/Nova/TaxonomyTheme.php`
+
+```php
+<?php
+
+namespace App\Nova;
+
+use Wm\WmPackage\Nova\TaxonomyTheme as WmTaxonomyTheme;
+
+class TaxonomyTheme extends WmTaxonomyTheme {}
+```
+
+---
+
+## Step 5d — Registra `TaxonomyTheme` nel menu Nova di maphub
+
+**File:** `maphub/app/Providers/NovaServiceProvider.php`
+
+Aggiungere `use App\Nova\TaxonomyTheme;` tra gli import e `MenuItem::resource(TaxonomyTheme::class)` nella sezione `Taxonomies`.
+
+---
+
+## Step 7 — PR
+
+Apri PR da `feature/oc-8014-import-taxonomy-theme-job` verso `develop` in `wm-package`.
+Apri PR da `feature/oc-8014-import-taxonomy-theme-job` verso `develop` in `maphub`.
+
+Descrizione PR: richiama i rischi noti (icon da decidere, config pubblicato da aggiornare nei progetti).

--- a/docs/features/8014-import-taxonomy-theme-job/plan.md
+++ b/docs/features/8014-import-taxonomy-theme-job/plan.md
@@ -133,6 +133,28 @@ Verificare che l'import della classe sia presente tra gli `use` in testa al file
 
 ---
 
+## Step 4b — Aggiorna `ImportAppJob` (fix critico)
+
+**File:** `src/Jobs/Import/ImportAppJob.php`
+
+**Modifica 1 — `processDependencies()`**: aggiungere il blocco `taxonomy_theme` dopo `taxonomy_poi_types` e prima di `ec_poi`:
+
+```php
+if (in_array('taxonomy_theme', $allowedDependencies)) {
+    $this->queueEntityImport('taxonomy_theme', $data['user_id'], 'user_id', $model->id);
+}
+```
+
+**Modifica 2 — `getAllowedDependencies()`**: aggiungere `'taxonomy_theme'` al fallback `$allDependencies`, mantenendo l'ordine: tutti i taxonomy prima delle entità EC:
+
+```php
+$allDependencies = ['taxonomy_activity', 'taxonomy_poi_types', 'taxonomy_theme', 'ec_poi', 'ec_track', 'layer', 'ec_media'];
+```
+
+Il `queueEntityImport` gestisce già i taxonomy genericamente tramite `strpos($entityModelKey, 'taxonomy') !== false` → `$whereCondition = null`. Nessuna modifica allo switch.
+
+---
+
 ## Step 5 — Verifica pre-test
 
 Prima di testare su un ambiente con GeoHub accessibile:

--- a/src/Commands/WmImportFromGeohubCommand.php
+++ b/src/Commands/WmImportFromGeohubCommand.php
@@ -75,7 +75,7 @@ class WmImportFromGeohubCommand extends Command
     protected function prepareJobData(bool $skipDependencies, array $dependencies): array
     {
         // All available dependencies
-        $allDependencies = ['taxonomy_activity', 'taxonomy_poi_types', 'ec_poi', 'ec_track', 'layer', 'ec_media'];
+        $allDependencies = ['taxonomy_activity', 'taxonomy_theme', 'taxonomy_poi_types', 'ec_poi', 'ec_track', 'layer', 'ec_media'];
 
         if ($skipDependencies) {
             // Skip all dependencies

--- a/src/Jobs/Import/ImportAppJob.php
+++ b/src/Jobs/Import/ImportAppJob.php
@@ -52,6 +52,10 @@ class ImportAppJob extends BaseImportJob
             $this->queueEntityImport('taxonomy_poi_types', $data['user_id'], 'user_id', $model->id);
         }
 
+        if (in_array('taxonomy_theme', $allowedDependencies)) {
+            $this->queueEntityImport('taxonomy_theme', $data['user_id'], 'user_id', $model->id);
+        }
+
         if (in_array('ec_poi', $allowedDependencies)) {
             $this->queueEntityImport('ec_poi', $data['user_id'], 'user_id', $model->id);
         }
@@ -75,7 +79,7 @@ class ImportAppJob extends BaseImportJob
     protected function getAllowedDependencies(): array
     {
         // All available dependencies
-        $allDependencies = ['taxonomy_activity', 'taxonomy_poi_types', 'ec_poi', 'ec_track',  'layer', 'ec_media'];
+        $allDependencies = ['taxonomy_activity', 'taxonomy_poi_types', 'taxonomy_theme', 'ec_poi', 'ec_track', 'layer', 'ec_media'];
 
         // First check if allowed_dependencies is passed in job data
         if (isset($this->data['allowed_dependencies']) && is_array($this->data['allowed_dependencies'])) {

--- a/src/Jobs/Import/ImportTaxonomyJob.php
+++ b/src/Jobs/Import/ImportTaxonomyJob.php
@@ -23,16 +23,8 @@ abstract class ImportTaxonomyJob extends BaseImportJob
 
         \Log::info("Processing {$recordsToImport->count()} records for taxonomy model: {$model->id}");
 
-        // Prepare sync data for batch operation
-        $syncData = [];
         foreach ($recordsToImport as $record) {
-            $pivotData = $record->pivot_data ?? [];
-            $syncData[$record->id] = $pivotData;
-        }
-
-        // Use sync for efficient batch operation
-        foreach ($recordsToImport as $record) {
-            $record->{$this->getRelationshipName()}()->sync([$model->id => $record->pivot_data ?? []]);
+            $record->{$this->getRelationshipName()}()->syncWithoutDetaching([$model->id => $record->pivot_data ?? []]);
         }
     }
 

--- a/src/Jobs/Import/ImportTaxonomyThemeJob.php
+++ b/src/Jobs/Import/ImportTaxonomyThemeJob.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Wm\WmPackage\Jobs\Import;
+
+use Illuminate\Support\Facades\Log;
+use Wm\WmPackage\Services\Import\GeohubImportService;
+
+class ImportTaxonomyThemeJob extends ImportTaxonomyJob
+{
+    public $timeout = 300;
+
+    public function getModelKey(): string
+    {
+        return parent::getModelKey().'theme';
+    }
+
+    protected function getForeignKey(): string
+    {
+        return 'taxonomy_theme_id';
+    }
+
+    protected function getRelationshipName(): string
+    {
+        return 'taxonomyThemes';
+    }
+
+    public function handle(GeohubImportService $importService): void
+    {
+        try {
+            parent::handle($importService);
+        } catch (\Exception $e) {
+            Log::error('ImportTaxonomyThemeJob failed: '.$e->getMessage(), [
+                'entity_id' => $this->entityId ?? null,
+            ]);
+        }
+    }
+}

--- a/src/Nova/TaxonomyTheme.php
+++ b/src/Nova/TaxonomyTheme.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Wm\WmPackage\Nova;
+
+use Laravel\Nova\Fields\MorphToMany;
+use Laravel\Nova\Http\Requests\NovaRequest;
+
+class TaxonomyTheme extends AbstractTaxonomyResource
+{
+    public static $model = \Wm\WmPackage\Models\TaxonomyTheme::class;
+
+    public static $title = 'name';
+
+    public function fields(NovaRequest $request): array
+    {
+        return [
+            ...parent::fields($request),
+            MorphToMany::make('Tracks Associate', 'ecTracks', EcTrack::class)
+                ->display('name'),
+        ];
+    }
+}

--- a/src/Services/Import/GeohubImportService.php
+++ b/src/Services/Import/GeohubImportService.php
@@ -37,6 +37,7 @@ class GeohubImportService
     protected const MODEL_IMPORT_ORDER = [
         'app',
         'taxonomy_activity',
+        'taxonomy_theme',
         'taxonomy_poi_types',
         'ec_poi',
         'ec_track',


### PR DESCRIPTION
- Add ImportTaxonomyThemeJob following ImportTaxonomyActivityJob pattern
- Add TaxonomyTheme Nova resource extending AbstractTaxonomyResource
- Register taxonomy_theme in MODEL_IMPORT_ORDER and default_dependencies
- Populate job, fields (incl. icon via svgIconToNameIcon), properties in wm-geohub-import.php
- Add taxonomy_theme to WmImportFromGeohubCommand allowed dependencies
- Add migration stubs for taxonomy_themes and taxonomy_themeables tables

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
