### PR TITLE
fix(oc:8063): sync properties['name'] from getTranslations in EcPoiRowProcessor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,17 @@
 
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
+| Fix import Excel POI: nomi mancanti in pois.geojson | oc:8063 | `src/Imports/Processors/EcPoiRowProcessor.php`, `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php` | Sync `properties['name']` da `getTranslations('name')` in `apply()` — replica logica observer bypassata da `saveQuietly()` |
 | Fix getTaxonomyMorphableRecords | oc:8013 | `src/Jobs/Import/ImportTaxonomyJob.php` | Corregge il parametro passato a getTaxonomyMorphableRecords: entityId (GeoHub) invece di model->id (Maphub) |
 | Refactor SuperAdminService | oc:8006 | `src/Services/RolesAndPermissionsService.php`, `src/Support/SuperAdminService.php` (rimosso), `src/Nova/App.php`, `src/Nova/Actions/GenerateAppIconsAction.php`, `src/Nova/Actions/BuildAppPoisGeojsonAction.php`, `src/Policies/AppPolicy.php` | Sposta i check super-admin email-based in RolesAndPermissionsService; rimuove SuperAdminService |
 
 ## Decisioni architetturali
+
+### Fix import Excel POI nomi mancanti (oc:8063)
+- `EcPoiRowProcessor::apply()` deve sincronizzare `properties['name']` da `getTranslations('name')` dopo il loop — `saveQuietly()` bypassa `AbstractObserver::saving()` che normalmente fa questa sync
+- La logica è duplicata tra observer e processor: tech debt noto, accettato per mantenere il fix minimale
+- In update mode il merge delle traduzioni è implicito: il modello caricato dal DB porta già tutte le lingue, `setTranslation` aggiorna solo la locale fornita
+- `EcTrackRowProcessor` non è affetto: non usa `setTranslation` per il nome
 
 ### Fix getTaxonomyMorphableRecords (oc:8013)
 - `processDependencies()` deve passare `$this->entityId` (ID GeoHub) a `getTaxonomyMorphableRecords()`, non `$model->id` (ID Maphub locale) — i due ID sono diversi e il metodo interroga il DB GeoHub

--- a/docs/features/8063-import-excel-poi-i-nomi-non-compaiono-in-pois-geojson/notes.md
+++ b/docs/features/8063-import-excel-poi-i-nomi-non-compaiono-in-pois-geojson/notes.md
@@ -1,0 +1,22 @@
+> Ticket: oc:8063
+
+# Notes — Import Excel POI: i nomi non compaiono in pois.geojson
+
+## Deviazioni dal piano
+
+Nessuna deviazione. Il fix è stato implementato esattamente come descritto nel piano e nelle note dev del ticket.
+
+## Bug trovati
+
+Nessuno durante l'implementazione.
+
+## Decisioni
+
+- **EcTrackRowProcessor non è affetto**: verificato durante la Challenge — il processor di EcTrack non gestisce `name_it`/`name_en` e non usa `setTranslation`, quindi non ha lo stesso problema.
+- **Merge implicito in update mode**: il rischio di perdita traduzioni in lingue non presenti nel file Excel (sollevato dalla review adversariale) è un falso positivo. In update mode il modello è caricato dal DB con tutte le lingue già persistite; `setTranslation` aggiorna solo la locale fornita; `getTranslations('name')` restituisce l'array completo — nessuna lingua viene persa.
+- **Duplicazione logica observer/processor**: la logica di sync è ora presente sia in `AbstractObserver::saving()` sia in `EcPoiRowProcessor::apply()`. Accettata come tech debt noto; estrarre un metodo condiviso sarebbe un refactor separato fuori scope.
+
+## Follow-up
+
+- POI già importati prima del fix restano con `properties.name` assente nel GeoJSON. Workaround: re-import con `id` valorizzato + "Rigenera pois.geojson" su Nova (documentato nel ticket).
+- Valutare in futuro se estrarre la logica di sync in un metodo condiviso tra observer e processor per evitare divergenze future.

--- a/docs/features/8063-import-excel-poi-i-nomi-non-compaiono-in-pois-geojson/overview.md
+++ b/docs/features/8063-import-excel-poi-i-nomi-non-compaiono-in-pois-geojson/overview.md
@@ -1,0 +1,37 @@
+> Ticket: oc:8063
+
+# Import Excel POI: i nomi non compaiono in pois.geojson
+
+## Cosa cambia
+
+`EcPoiRowProcessor::apply()` sincronizza `properties['name']` da `getTranslations('name')` al termine del loop, replicando la logica di `AbstractObserver::saving()` che viene bypassata da `saveQuietly()`. Dopo il fix, i POI importati da Excel compaiono con il nome corretto nel `pois.geojson`.
+
+## Perché
+
+L'import Excel usa `saveQuietly()` per non triggerare la catena di observer per ogni riga (DEM, taxonomy_where, job rigenerazione GeoJSON). Questo bypassa anche `AbstractObserver::saving()`, che normalmente copia `getTranslations('name')` → `properties['name']`. Il GeoJSON legge da `properties`, non dalla colonna `name`: i POI risultavano salvati correttamente in DB/Nova ma senza nome nel file GeoJSON su S3.
+
+## Requisiti
+
+- [ ] `EcPoiRowProcessor::apply()` sincronizza `properties['name']` da `getTranslations('name')` dopo il loop, solo se il modello ha `getTranslations` e le traduzioni non sono vuote (`if ($name !== [])`)
+- [ ] Test esistente `apply_builds_point_geometry_from_lat_lng_and_writes_properties` aggiornato: anonymous model con `getTranslations`, asserzione `$properties['name'] === ['it' => 'Rifugio', 'en' => 'Refuge']`
+- [ ] Nuovo test: solo `name_it` fornito → `properties['name'] === ['it' => '...']` (nessuna chiave `en`)
+- [ ] Nuovo test: modello senza `getTranslations` → `properties['name']` non viene scritto (guard `method_exists` rispettato)
+
+## Rischi
+
+- **PHPStan**: chiamata `$model->getTranslations('name')` dopo `method_exists` su tipo `Model` — stesso pattern già in uso in `apply()` per `setTranslation`, non presente in baseline. Livello PHPStan nel package è 4. Rischio basso; verificare in Docker.
+- **Import parziale**: in create mode con solo `name_it`, `properties['name']` sarà `['it' => '...']` senza `en`. Il GeoJSON (`GeoJsonService::getModelAsGeojson`) legge `properties` as-is, nessuna trasformazione — comportamento corretto.
+
+## Out of scope
+
+- Trigger automatico di rigenerazione GeoJSON dopo import (l'uso di `saveQuietly()` è intenzionale per performance)
+- Sync di `description` ed `excerpt` (già scritti in `properties` direttamente nel loop, non hanno questo problema)
+- Migration/command per POI esistenti importati senza nome (workaround documentato nel ticket: re-import con `id` + "Rigenera pois.geojson" su Nova)
+- Altre lingue oltre `it` ed `en` (il fix è generico: usa `getTranslations('name')` che restituisce tutte le lingue disponibili)
+
+## Moduli toccati
+
+| File | Repo | Modifica |
+|---|---|---|
+| `src/Imports/Processors/EcPoiRowProcessor.php` | wm-package | Aggiunta sync `properties['name']` dopo il loop in `apply()` |
+| `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php` | wm-package | Aggiornamento test esistente + 2 nuovi casi |

--- a/docs/features/8063-import-excel-poi-i-nomi-non-compaiono-in-pois-geojson/plan.md
+++ b/docs/features/8063-import-excel-poi-i-nomi-non-compaiono-in-pois-geojson/plan.md
@@ -1,0 +1,190 @@
+> Ticket: oc:8063
+
+# Plan — Import Excel POI: i nomi non compaiono in pois.geojson
+
+## Repo coinvolto
+
+`wm-package` — tutto il codice e i test vivono qui. Nessuna modifica al repo principale (maphub).
+
+## Branch
+
+`oc_8063` (già creato in locale su wm-package)
+
+## Commit convention
+
+`fix(oc:8063): <descrizione>`
+
+---
+
+## Step 1 — Fix `EcPoiRowProcessor::apply()`
+
+**File:** `src/Imports/Processors/EcPoiRowProcessor.php`
+
+Aggiungere, **dopo il loop `foreach`** e **prima** di `$model->setAttribute('properties', $properties)` (attualmente riga 197), il blocco di sincronizzazione:
+
+```php
+if (method_exists($model, 'getTranslations')) {
+    $name = $model->getTranslations('name');
+    if ($name !== []) {
+        $properties['name'] = $name;
+    }
+}
+```
+
+Il codice risultante alla fine di `apply()` sarà:
+
+```php
+        if ($lat !== null && $lng !== null && is_numeric($lat) && is_numeric($lng)) {
+            $latF = (float) $lat;
+            $lngF = (float) $lng;
+            $model->setAttribute('geometry', "POINT Z ({$lngF} {$latF} 0)");
+        }
+
+        if (method_exists($model, 'getTranslations')) {
+            $name = $model->getTranslations('name');
+            if ($name !== []) {
+                $properties['name'] = $name;
+            }
+        }
+
+        $model->setAttribute('properties', $properties);
+    }
+```
+
+**Logica:** replica `AbstractObserver::saving()` per il path `saveQuietly()`. La guard `method_exists` è coerente con il pattern già usato in `apply()` per `setTranslation`. La guard `!== []` evita di scrivere `properties['name'] = []` quando nessuna traduzione è stata fornita.
+
+---
+
+## Step 2 — Aggiornare `EcPoiRowProcessorTest`
+
+**File:** `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php`
+
+### 2a — Aggiornare il test esistente `apply_builds_point_geometry_from_lat_lng_and_writes_properties`
+
+1. Aggiungere `getTranslations` all'anonymous model:
+
+```php
+public function getTranslations(string $key): array
+{
+    $map = $this->getAttribute($key) ?? [];
+    return is_array($map) ? $map : [];
+}
+```
+
+2. Aggiungere l'asserzione su `properties['name']` dopo quelle esistenti:
+
+```php
+$this->assertSame(['it' => 'Rifugio', 'en' => 'Refuge'], $properties['name']);
+```
+
+### 2b — Aggiungere test "solo name_it"
+
+```php
+/** @test */
+public function apply_writes_only_provided_translations_to_properties_name(): void
+{
+    $model = new class extends Model
+    {
+        protected $guarded = [];
+        public $timestamps = false;
+
+        public function setTranslation(string $key, string $locale, string $value): void
+        {
+            $map = $this->getAttribute($key) ?? [];
+            $map = is_array($map) ? $map : [];
+            $map[$locale] = $value;
+            $this->setAttribute($key, $map);
+        }
+
+        public function getTranslations(string $key): array
+        {
+            $map = $this->getAttribute($key) ?? [];
+            return is_array($map) ? $map : [];
+        }
+    };
+
+    $data = [
+        'name_it' => 'Rifugio',
+        'poi_type' => 'rifugio',
+        'lat' => '45.5',
+        'lng' => '10.25',
+    ];
+
+    (new EcPoiRowProcessor)->apply($model, $data);
+
+    $properties = $model->getAttribute('properties');
+    $this->assertSame(['it' => 'Rifugio'], $properties['name']);
+    $this->assertArrayNotHasKey('en', $properties['name']);
+}
+```
+
+### 2c — Aggiungere test "modello senza getTranslations"
+
+```php
+/** @test */
+public function apply_does_not_write_properties_name_when_model_has_no_get_translations(): void
+{
+    $model = new class extends Model
+    {
+        protected $guarded = [];
+        public $timestamps = false;
+
+        public function setTranslation(string $key, string $locale, string $value): void
+        {
+            $map = $this->getAttribute($key) ?? [];
+            $map = is_array($map) ? $map : [];
+            $map[$locale] = $value;
+            $this->setAttribute($key, $map);
+        }
+        // getTranslations NON implementato: verifica che il guard method_exists funzioni
+    };
+
+    $data = [
+        'name_it' => 'Rifugio',
+        'poi_type' => 'rifugio',
+        'lat' => '45.5',
+        'lng' => '10.25',
+    ];
+
+    (new EcPoiRowProcessor)->apply($model, $data);
+
+    $properties = $model->getAttribute('properties');
+    $this->assertArrayNotHasKey('name', $properties);
+}
+```
+
+---
+
+## Step 3 — Eseguire i test
+
+```bash
+# Dalla root di wm-package (nel container o con PHP 8.4 locale)
+vendor/bin/pest tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php
+```
+
+Tutti e 4 i test devono passare (il pre-esistente + i 3 aggiornati/nuovi).
+
+---
+
+## Step 4 — PHPStan
+
+```bash
+# Nel container Docker
+docker exec -it php-${APP_NAME} bash -c "cd /var/www/html/wm-package && vendor/bin/phpstan analyse src/Imports/Processors/EcPoiRowProcessor.php --no-progress"
+```
+
+Se PHPStan segnala `Call to an undefined method` sul blocco `getTranslations`, aggiungere `@phpstan-ignore-next-line` — lo stesso approccio usato altrove nel codebase per il duck-typing.
+
+---
+
+## Step 5 — Commit
+
+```
+fix(oc:8063): sync properties['name'] from getTranslations in EcPoiRowProcessor::apply()
+```
+
+File da includere:
+- `src/Imports/Processors/EcPoiRowProcessor.php`
+- `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php`
+
+> ⚠️ Nessun commit automatico. L'esecuzione del commit richiede approvazione esplicita del developer dopo revisione del diff.

--- a/src/Imports/Processors/EcPoiRowProcessor.php
+++ b/src/Imports/Processors/EcPoiRowProcessor.php
@@ -194,6 +194,13 @@ final class EcPoiRowProcessor
             $model->setAttribute('geometry', "POINT Z ({$lngF} {$latF} 0)");
         }
 
+        if (method_exists($model, 'getTranslations')) {
+            $name = $model->getTranslations('name');
+            if ($name !== []) {
+                $properties['name'] = $name;
+            }
+        }
+
         $model->setAttribute('properties', $properties);
     }
 

--- a/tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php
+++ b/tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php
@@ -35,6 +35,13 @@ class EcPoiRowProcessorTest extends TestCase
                 $map[$locale] = $value;
                 $this->setAttribute($key, $map);
             }
+
+            public function getTranslations(string $key): array
+            {
+                $map = $this->getAttribute($key) ?? [];
+
+                return is_array($map) ? $map : [];
+            }
         };
 
         $data = [
@@ -60,6 +67,7 @@ class EcPoiRowProcessorTest extends TestCase
         $properties = $model->getAttribute('properties');
         $this->assertSame('Rifugio', $model->getAttribute('name')['it'] ?? null);
         $this->assertSame('Refuge', $model->getAttribute('name')['en'] ?? null);
+        $this->assertSame(['it' => 'Rifugio', 'en' => 'Refuge'], $properties['name']);
         $this->assertSame(['it' => 'desc it'], $properties['description']);
         $this->assertSame('rifugio', $properties['poi_type']);
         $this->assertSame('Via Roma 1', $properties['addr_complete']);
@@ -68,5 +76,75 @@ class EcPoiRowProcessorTest extends TestCase
         $this->assertSame(['https://example.com' => 'https://example.com'], $properties['related_url']);
         $this->assertArrayNotHasKey('errors', $properties);
         $this->assertArrayNotHasKey('unknown_column', $properties);
+    }
+
+    /** @test */
+    public function apply_writes_only_provided_translations_to_properties_name(): void
+    {
+        $model = new class extends Model
+        {
+            protected $guarded = [];
+
+            public $timestamps = false;
+
+            public function setTranslation(string $key, string $locale, string $value): void
+            {
+                $map = $this->getAttribute($key) ?? [];
+                $map = is_array($map) ? $map : [];
+                $map[$locale] = $value;
+                $this->setAttribute($key, $map);
+            }
+
+            public function getTranslations(string $key): array
+            {
+                $map = $this->getAttribute($key) ?? [];
+
+                return is_array($map) ? $map : [];
+            }
+        };
+
+        $data = [
+            'name_it' => 'Rifugio',
+            'poi_type' => 'rifugio',
+            'lat' => '45.5',
+            'lng' => '10.25',
+        ];
+
+        (new EcPoiRowProcessor)->apply($model, $data);
+
+        $properties = $model->getAttribute('properties');
+        $this->assertSame(['it' => 'Rifugio'], $properties['name']);
+        $this->assertArrayNotHasKey('en', $properties['name']);
+    }
+
+    /** @test */
+    public function apply_does_not_write_properties_name_when_model_has_no_get_translations(): void
+    {
+        $model = new class extends Model
+        {
+            protected $guarded = [];
+
+            public $timestamps = false;
+
+            public function setTranslation(string $key, string $locale, string $value): void
+            {
+                $map = $this->getAttribute($key) ?? [];
+                $map = is_array($map) ? $map : [];
+                $map[$locale] = $value;
+                $this->setAttribute($key, $map);
+            }
+        };
+
+        $data = [
+            'name_it' => 'Rifugio',
+            'poi_type' => 'rifugio',
+            'lat' => '45.5',
+            'lng' => '10.25',
+        ];
+
+        (new EcPoiRowProcessor)->apply($model, $data);
+
+        $properties = $model->getAttribute('properties');
+        $this->assertArrayNotHasKey('name', $properties);
     }
 }


### PR DESCRIPTION
## Summary

- **Bug**: dopo l'import Excel POI via Nova, `pois.geojson` mostrava i POI senza `properties.name` nonostante i nomi fossero correttamente salvati in DB
- **Root cause**: l'import usa `saveQuietly()`, che bypassa `AbstractObserver::saving()` — il metodo che normalmente sincronizza `getTranslations('name')` → `properties['name']`
- **Fix**: aggiunto il blocco di sync in `EcPoiRowProcessor::apply()` dopo il loop, replicando la logica dell'observer

## Changes

- `src/Imports/Processors/EcPoiRowProcessor.php` — sync `properties['name']` da `getTranslations('name')` con guard `method_exists` + `!== []`
- `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php` — test esistente aggiornato + 2 nuovi casi (solo-IT, modello senza `getTranslations`)

## Test plan

- [ ] `vendor/bin/pest tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php` — tutti e 4 i test passano
- [ ] Import manuale `.xlsx` con `name_it` + `name_en` → "Rigenera pois.geojson" → verificare `properties.name` in S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)