### PR TITLE
feat(nova): disable geolocation field when auth_show_at_startup is off OC:7852

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ protected static function newFactory(): Factory
 | Fix mappa layer bounding box | oc:8093 | `src/Nova/Fields/FeatureCollectionMap/dist/js/field.js` | Dist ricompilato: rimossa prop `inline-geojson:field.geojson` introdotta per errore in `fb3c0555` (oc:7756) |
 | Fix import Excel POI: nomi mancanti in pois.geojson | oc:8063 | `src/Imports/Processors/EcPoiRowProcessor.php`, `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php` | Sync `properties['name']` da `getTranslations('name')` in `apply()` — replica logica observer bypassata da `saveQuietly()` |
 | ImportTaxonomyThemeJob | oc:8014 | `src/Jobs/Import/ImportTaxonomyThemeJob.php`, `src/Services/Import/GeohubImportService.php`, `config/wm-geohub-import.php` | Aggiunge il job mancante per importare TaxonomyTheme da GeoHub; registra taxonomy_theme in MODEL_IMPORT_ORDER e default_dependencies |
-| Dipendenza visiva auth → geolocalizzazione in Nova | oc:7852 | `src/Nova/App.php`, `resources/lang/it.json` | `mobileAuthDependent()` grayed-out `geolocation_record_enable` quando `auth_show_at_startup=false`; solo UI, nessuna modifica al DB |
+| Dipendenza visiva auth → geolocalizzazione in Nova | oc:7852 | `src/Nova/App.php`, `resources/lang/it.json` | HTML field `onlyOnDetail()` con valore calcolato; `mobileAuthDependent()` mantiene grayed-out in edit; Boolean `onlyOnForms()` evita duplicazione in detail |
 | Fix getTaxonomyMorphableRecords | oc:8013 | `src/Jobs/Import/ImportTaxonomyJob.php` | Corregge il parametro passato a getTaxonomyMorphableRecords: entityId (GeoHub) invece di model->id (Maphub) |
 | Refactor SuperAdminService | oc:8006 | `src/Services/RolesAndPermissionsService.php`, `src/Support/SuperAdminService.php` (rimosso), `src/Nova/App.php`, `src/Nova/Actions/GenerateAppIconsAction.php`, `src/Nova/Actions/BuildAppPoisGeojsonAction.php`, `src/Policies/AppPolicy.php` | Sposta i check super-admin email-based in RolesAndPermissionsService; rimuove SuperAdminService |
 
@@ -62,10 +62,10 @@ protected static function newFactory(): Factory
 - `taxonomy_when` e `taxonomy_target` hanno lo stesso problema (`'job' => ''`) — esclusi da questo ticket, servono ticket separati
 
 ### Dipendenza visiva auth → geolocalizzazione (oc:7852)
-- `dependsOn` in Nova 5 viene usato con `->readonly(true)` nel callback per oscurare campi dipendenti — non con `->hide()`, così la dipendenza rimane visibile all'admin
-- Il metodo privato `mobileAuthDependent(Boolean $field): Boolean` centralizza la logica: aggiungere futuri campi dipendenti da `auth_show_at_startup` basta wrapparlo con questo helper
+- In detail view: `Text::make(..., fn() => ...)->asHtml()->onlyOnDetail()` mostra icona verde se `auth_show_at_startup && geolocation_record_enable`, rossa altrimenti — heroicons 24/solid `w-6 h-6`, stesso rendering dei Boolean nativi Nova
+- In edit/create: `mobileAuthDependent()` mantiene il grayed-out (`->readonly(true)`) quando `auth_show_at_startup=false`; Boolean con `->onlyOnForms()` (non `hideFromIndex()`) per evitare duplicazione in detail
 - `webappAuthDependent()` non creato: rimandato a quando esisterà un campo dipendente reale nel tab Webapp
-- `AppConfigService` non modificato: il config generato riflette sempre il valore reale nel DB, indipendentemente dallo stato UI
+- `AppConfigService` non modificato: il config generato riflette sempre il valore reale nel DB
 
 ### Fix getTaxonomyMorphableRecords (oc:8013)
 - `processDependencies()` deve passare `$this->entityId` (ID GeoHub) a `getTaxonomyMorphableRecords()`, non `$model->id` (ID Maphub locale) — i due ID sono diversi e il metodo interroga il DB GeoHub

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ protected static function newFactory(): Factory
 | Fix mappa layer bounding box | oc:8093 | `src/Nova/Fields/FeatureCollectionMap/dist/js/field.js` | Dist ricompilato: rimossa prop `inline-geojson:field.geojson` introdotta per errore in `fb3c0555` (oc:7756) |
 | Fix import Excel POI: nomi mancanti in pois.geojson | oc:8063 | `src/Imports/Processors/EcPoiRowProcessor.php`, `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php` | Sync `properties['name']` da `getTranslations('name')` in `apply()` — replica logica observer bypassata da `saveQuietly()` |
 | ImportTaxonomyThemeJob | oc:8014 | `src/Jobs/Import/ImportTaxonomyThemeJob.php`, `src/Services/Import/GeohubImportService.php`, `config/wm-geohub-import.php` | Aggiunge il job mancante per importare TaxonomyTheme da GeoHub; registra taxonomy_theme in MODEL_IMPORT_ORDER e default_dependencies |
+| Dipendenza visiva auth → geolocalizzazione in Nova | oc:7852 | `src/Nova/App.php`, `resources/lang/it.json` | `mobileAuthDependent()` grayed-out `geolocation_record_enable` quando `auth_show_at_startup=false`; solo UI, nessuna modifica al DB |
 | Fix getTaxonomyMorphableRecords | oc:8013 | `src/Jobs/Import/ImportTaxonomyJob.php` | Corregge il parametro passato a getTaxonomyMorphableRecords: entityId (GeoHub) invece di model->id (Maphub) |
 | Refactor SuperAdminService | oc:8006 | `src/Services/RolesAndPermissionsService.php`, `src/Support/SuperAdminService.php` (rimosso), `src/Nova/App.php`, `src/Nova/Actions/GenerateAppIconsAction.php`, `src/Nova/Actions/BuildAppPoisGeojsonAction.php`, `src/Policies/AppPolicy.php` | Sposta i check super-admin email-based in RolesAndPermissionsService; rimuove SuperAdminService |
 
@@ -59,6 +60,12 @@ protected static function newFactory(): Factory
 - `ImportTaxonomyJob::processDependencies()` usa `syncWithoutDetaching()` (non `sync()`): `sync()` azzerava tutte le associazioni del record lasciando solo l'ultimo tema importato — bug critico confermato su app 63.
 - Dopo merge: i progetti con config già pubblicato devono aggiornare manualmente `default_dependencies['app']` in `wm-geohub-import.php` oppure ri-pubblicare con `--force`
 - `taxonomy_when` e `taxonomy_target` hanno lo stesso problema (`'job' => ''`) — esclusi da questo ticket, servono ticket separati
+
+### Dipendenza visiva auth → geolocalizzazione (oc:7852)
+- `dependsOn` in Nova 5 viene usato con `->readonly(true)` nel callback per oscurare campi dipendenti — non con `->hide()`, così la dipendenza rimane visibile all'admin
+- Il metodo privato `mobileAuthDependent(Boolean $field): Boolean` centralizza la logica: aggiungere futuri campi dipendenti da `auth_show_at_startup` basta wrapparlo con questo helper
+- `webappAuthDependent()` non creato: rimandato a quando esisterà un campo dipendente reale nel tab Webapp
+- `AppConfigService` non modificato: il config generato riflette sempre il valore reale nel DB, indipendentemente dallo stato UI
 
 ### Fix getTaxonomyMorphableRecords (oc:8013)
 - `processDependencies()` deve passare `$this->entityId` (ID GeoHub) a `getTaxonomyMorphableRecords()`, non `$model->id` (ID Maphub locale) — i due ID sono diversi e il metodo interroga il DB GeoHub

--- a/docs/features/7852-gestione-automatica-parametri-app-autenticazione/notes.md
+++ b/docs/features/7852-gestione-automatica-parametri-app-autenticazione/notes.md
@@ -4,8 +4,9 @@
 
 ## Deviazioni dal piano
 
-- **Step 1 skippato:** la verifica empirica `dependsOn` nei tab annidati richiede browser — non eseguita durante l'implementazione automatica. Deve essere eseguita manualmente prima del merge (vedi Step 5 del plan).
-- **Help text aggiunto (non nel plan originale):** l'utente ha richiesto che il campo grayed out mostri un testo esplicativo. Il metodo `mobileAuthDependent()` appende dinamicamente il lockMessage all'help text originale del campo tramite `implode(' — ', array_filter([$field->helpText, $lockMessage]))`.
+- **Step 1 originale (verifica empirica `dependsOn`) skippato:** richiede browser — da eseguire manualmente prima del merge.
+- **HTML field aggiunto per detail view (non nel piano originale):** decisione di riunione con Giuseppe — la detail view deve mostrare il valore effettivo calcolato (false se padre è false), non il valore grezzo del DB.
+- **Boolean cambiato da `hideFromIndex()` a `onlyOnForms()`:** necessario per evitare che il Boolean appaia anche in detail view dove già c'è l'HTML field (duplicazione). `mobileAuthDependent()` rimane attivo in edit.
 
 ## Bug trovati
 
@@ -13,12 +14,11 @@ Nessuno.
 
 ## Decisioni
 
-- **Solo UI, nessuna modifica al DB:** l'approccio finale è puramente visivo — `->readonly(true)` + help text concatenato nel callback `dependsOn`. Il DB non viene mai toccato, il valore reale rimane visibile (grayed out).
-- **Backup-restore via observer scartato:** durante l'implementazione è stato esplorato un approccio in cui l'observer salvava il valore originale in `properties['_auth_backup_geolocation']` e lo ripristinava al cambio di `auth_show_at_startup`. Abbandonato perché aumentava la complessità senza beneficio reale: il valore DB rimane sempre quello scelto dall'admin.
-- **`webappAuthDependent()` non creato:** rimandato a quando esisterà un consumatore reale nel tab Webapp.
-- **`AppConfigService` non modificato:** il config generato legge il valore reale dal DB, indipendentemente dallo stato UI.
+- **HTML field in detail view:** `Text::make(..., fn() => ...)->asHtml()->onlyOnDetail()` mostra icona verde se `auth_show_at_startup && geolocation_record_enable`, rossa altrimenti. SVG da `@heroicons/vue@2.2.0` 24/solid (`w-6 h-6`) — stessa dimensione del Boolean nativo Nova. Pattern già usato nel file per `pois_data_icon`/`tracks_data_icon`.
+- **`mobileAuthDependent()` mantenuto in edit:** il grayed-out in edit rimane attivo — l'utente può ancora modificare il campo ma riceve feedback visivo. Non rimosso per decisione esplicita.
+- **`AppConfigService` non modificato:** il config generato legge il valore reale dal DB, indipendentemente dalla visualizzazione Nova.
 
 ## Follow-up
 
-- Creare `webappAuthDependent()` quando vengono aggiunti campi dipendenti da `webapp_auth_show_at_startup` nel tab Webapp.
+- Creare `webappAuthDependent()` (o equivalente HTML) quando vengono aggiunti campi dipendenti da `webapp_auth_show_at_startup` nel tab Webapp.
 - Se in futuro si vuole enforced coerenza nel config, aggiornare `AppConfigService::config_section_geolocation()` per sopprimere `GEOLOCATION.record.enable` quando `auth_show_at_startup = false`.

--- a/docs/features/7852-gestione-automatica-parametri-app-autenticazione/notes.md
+++ b/docs/features/7852-gestione-automatica-parametri-app-autenticazione/notes.md
@@ -1,0 +1,24 @@
+> Ticket: oc:7852
+
+# Notes — Gestione automatica dei parametri di App dipendenti da autenticazione
+
+## Deviazioni dal piano
+
+- **Step 1 skippato:** la verifica empirica `dependsOn` nei tab annidati richiede browser — non eseguita durante l'implementazione automatica. Deve essere eseguita manualmente prima del merge (vedi Step 5 del plan).
+- **Help text aggiunto (non nel plan originale):** l'utente ha richiesto che il campo grayed out mostri un testo esplicativo. Il metodo `mobileAuthDependent()` appende dinamicamente il lockMessage all'help text originale del campo tramite `implode(' — ', array_filter([$field->helpText, $lockMessage]))`.
+
+## Bug trovati
+
+Nessuno.
+
+## Decisioni
+
+- **Solo UI, nessuna modifica al DB:** l'approccio finale è puramente visivo — `->readonly(true)` + help text concatenato nel callback `dependsOn`. Il DB non viene mai toccato, il valore reale rimane visibile (grayed out).
+- **Backup-restore via observer scartato:** durante l'implementazione è stato esplorato un approccio in cui l'observer salvava il valore originale in `properties['_auth_backup_geolocation']` e lo ripristinava al cambio di `auth_show_at_startup`. Abbandonato perché aumentava la complessità senza beneficio reale: il valore DB rimane sempre quello scelto dall'admin.
+- **`webappAuthDependent()` non creato:** rimandato a quando esisterà un consumatore reale nel tab Webapp.
+- **`AppConfigService` non modificato:** il config generato legge il valore reale dal DB, indipendentemente dallo stato UI.
+
+## Follow-up
+
+- Creare `webappAuthDependent()` quando vengono aggiunti campi dipendenti da `webapp_auth_show_at_startup` nel tab Webapp.
+- Se in futuro si vuole enforced coerenza nel config, aggiornare `AppConfigService::config_section_geolocation()` per sopprimere `GEOLOCATION.record.enable` quando `auth_show_at_startup = false`.

--- a/docs/features/7852-gestione-automatica-parametri-app-autenticazione/overview.md
+++ b/docs/features/7852-gestione-automatica-parametri-app-autenticazione/overview.md
@@ -1,0 +1,42 @@
+> Ticket: oc:7852
+
+# Gestione automatica dei parametri di App dipendenti da autenticazione nel wm-package
+
+## Cosa cambia
+
+Nel form di edit/create Nova del modello App, i campi che dipendono dall'autenticazione appaiono oscurati (visibili ma non modificabili, grayed out) quando il campo principale "Show Auth at startup" è `false`. Il comportamento è puramente visivo: il valore nel database non viene mai letto, scritto o modificato da questa logica.
+
+## Perché
+
+Evitare configurazioni incoerenti: un admin potrebbe abilitare la geolocalizzazione senza rendersi conto che richiede l'autenticazione disabilitata. Il feedback visivo immediato chiarisce la dipendenza senza forzare modifiche ai dati.
+
+## Requisiti
+
+- [x] Nel form edit/create, quando `auth_show_at_startup` è `false`, il campo `geolocation_record_enable` appare oscurato (grayed out) tramite `->readonly(true)` nel callback `dependsOn` — il valore reale del DB rimane visibile
+- [x] Il valore di `geolocation_record_enable` nel database **non viene mai modificato** da questa feature
+- [x] `AppConfigService` non viene modificato — continua a leggere il valore reale dal DB
+- [x] Il tab Mobile espone un helper privato `mobileAuthDependent(Boolean $field): Boolean` riutilizzabile per futuri campi dipendenti da `auth_show_at_startup`
+- [x] L'helper `webappAuthDependent()` **non viene creato ora** — rimandato a quando esisterà un consumatore reale nel tab Webapp (documentato in `notes.md`)
+- [x] I campi dipendenti rimangono raggruppati visivamente subito sotto il rispettivo campo principale (ordine già corretto nel codice attuale)
+- [x] Il campo grayed out mostra un help text che spiega la dipendenza ("Requires authentication at startup to be enabled"), concatenato all'help text originale del campo
+- [ ] Verifica empirica che `dependsOn` su `Boolean` funzioni nei tab annidati di Nova 5 (da eseguire manualmente in browser)
+
+## Rischi
+
+- **`dependsOn` in tab annidati non testato:** `auth_show_at_startup` e `geolocation_record_enable` vivono entrambi dentro `mobile_tab()` → `Tab::group`. Se i due campi finiscono in componenti Vue separati il reactive binding potrebbe non propagarsi. Mitigazione: verifica manuale prima del merge — se non funziona, alternativa è un custom Vue component.
+- **Stato incoerente preesistente non sanato:** app già configurate con `geolocation_record_enable = true` e `auth_show_at_startup = false` non ricevono nessun segnale correttivo. Accettato: la feature gestisce solo le nuove interazioni via Nova, il DB non viene toccato.
+
+## Out of scope
+
+- Modifica del valore nel database quando `auth_show_at_startup` cambia
+- Aggiornamento di `AppConfigService` per sopprimere `GEOLOCATION.record.enable`
+- Helper `webappAuthDependent()` (rimandato a quando ci sarà un consumatore reale)
+- Validazione server-side sulla coerenza dei campi
+- Migrazione dati per app con stato incoerente preesistente
+
+## Moduli toccati
+
+| File | Repo | Modifica |
+|------|------|----------|
+| `src/Nova/App.php` | `wm-package` | Aggiunta metodo privato `mobileAuthDependent()`; `geolocation_record_enable` wrappato con `mobileAuthDependent()`; aggiunto import `FormData` |
+| `resources/lang/it.json` | `wm-package` | Aggiunta traduzione italiana per "Requires authentication at startup to be enabled" |

--- a/docs/features/7852-gestione-automatica-parametri-app-autenticazione/overview.md
+++ b/docs/features/7852-gestione-automatica-parametri-app-autenticazione/overview.md
@@ -4,27 +4,30 @@
 
 ## Cosa cambia
 
-Nel form di edit/create Nova del modello App, i campi che dipendono dall'autenticazione appaiono oscurati (visibili ma non modificabili, grayed out) quando il campo principale "Show Auth at startup" è `false`. Il comportamento è puramente visivo: il valore nel database non viene mai letto, scritto o modificato da questa logica.
+Nel form edit/create Nova del modello App, i campi che dipendono dall'autenticazione appaiono oscurati (visibili ma non modificabili, grayed out) quando il campo principale "Show Auth at startup" è `false`.
+
+Nella detail view Nova, lo stesso campo viene renderizzato come HTML con valore calcolato: icona verde se `auth_show_at_startup=true` AND `geolocation_record_enable=true` nel DB, icona rossa altrimenti.
+
+Il valore nel database non viene mai toccato da questa logica.
 
 ## Perché
 
-Evitare configurazioni incoerenti: un admin potrebbe abilitare la geolocalizzazione senza rendersi conto che richiede l'autenticazione disabilitata. Il feedback visivo immediato chiarisce la dipendenza senza forzare modifiche ai dati.
+Evitare configurazioni incoerenti: un admin potrebbe abilitare la geolocalizzazione senza rendersi conto che richiede l'autenticazione abilitata. Il feedback visivo immediato (grayed-out in edit, icona calcolata in detail) chiarisce la dipendenza senza forzare modifiche ai dati.
 
 ## Requisiti
 
-- [x] Nel form edit/create, quando `auth_show_at_startup` è `false`, il campo `geolocation_record_enable` appare oscurato (grayed out) tramite `->readonly(true)` nel callback `dependsOn` — il valore reale del DB rimane visibile
-- [x] Il valore di `geolocation_record_enable` nel database **non viene mai modificato** da questa feature
-- [x] `AppConfigService` non viene modificato — continua a leggere il valore reale dal DB
-- [x] Il tab Mobile espone un helper privato `mobileAuthDependent(Boolean $field): Boolean` riutilizzabile per futuri campi dipendenti da `auth_show_at_startup`
-- [x] L'helper `webappAuthDependent()` **non viene creato ora** — rimandato a quando esisterà un consumatore reale nel tab Webapp (documentato in `notes.md`)
-- [x] I campi dipendenti rimangono raggruppati visivamente subito sotto il rispettivo campo principale (ordine già corretto nel codice attuale)
-- [x] Il campo grayed out mostra un help text che spiega la dipendenza ("Requires authentication at startup to be enabled"), concatenato all'help text originale del campo
-- [ ] Verifica empirica che `dependsOn` su `Boolean` funzioni nei tab annidati di Nova 5 (da eseguire manualmente in browser)
+- [ ] In **detail view**: `geolocation_record_enable` viene renderizzato come HTML con icona calcolata: verde se `auth_show_at_startup && geolocation_record_enable`, rossa altrimenti (identica al rendering nativo dei Boolean field di Nova — heroicons 24/solid, `w-6 h-6`)
+- [ ] In **edit/create**: quando `auth_show_at_startup` è `false`, `geolocation_record_enable` appare grayed-out tramite `mobileAuthDependent()` (`->readonly(true)` nel callback `dependsOn`) con lockMessage — il valore reale del DB rimane visibile
+- [ ] Il valore di `geolocation_record_enable` nel database **non viene mai modificato** da questa feature
+- [ ] `AppConfigService` non viene modificato — continua a leggere il valore reale dal DB
+- [ ] Il tab Mobile espone un helper privato `mobileAuthDependent(Boolean $field): Boolean` riutilizzabile per futuri campi dipendenti da `auth_show_at_startup`
+- [ ] L'helper `webappAuthDependent()` **non viene creato ora** — rimandato a quando esisterà un consumatore reale nel tab Webapp
+- [ ] I campi dipendenti rimangono raggruppati visivamente subito sotto il rispettivo campo principale
 
 ## Rischi
 
-- **`dependsOn` in tab annidati non testato:** `auth_show_at_startup` e `geolocation_record_enable` vivono entrambi dentro `mobile_tab()` → `Tab::group`. Se i due campi finiscono in componenti Vue separati il reactive binding potrebbe non propagarsi. Mitigazione: verifica manuale prima del merge — se non funziona, alternativa è un custom Vue component.
-- **Stato incoerente preesistente non sanato:** app già configurate con `geolocation_record_enable = true` e `auth_show_at_startup = false` non ricevono nessun segnale correttivo. Accettato: la feature gestisce solo le nuove interazioni via Nova, il DB non viene toccato.
+- **Split field (HTML+Boolean sullo stesso attributo):** pattern già usato nel file per `pois_data_icon` e `tracks_data_icon` — nessun rischio architetturale nuovo.
+- **Stato incoerente preesistente non sanato:** app già configurate con `geolocation_record_enable = true` e `auth_show_at_startup = false` vedranno il campo come falso in detail ma il DB mantiene il valore reale. Accettato: la detail view riflette l'effetto reale sull'app, il DB mantiene la preconfigurazione admin.
 
 ## Out of scope
 
@@ -38,5 +41,5 @@ Evitare configurazioni incoerenti: un admin potrebbe abilitare la geolocalizzazi
 
 | File | Repo | Modifica |
 |------|------|----------|
-| `src/Nova/App.php` | `wm-package` | Aggiunta metodo privato `mobileAuthDependent()`; `geolocation_record_enable` wrappato con `mobileAuthDependent()`; aggiunto import `FormData` |
-| `resources/lang/it.json` | `wm-package` | Aggiunta traduzione italiana per "Requires authentication at startup to be enabled" |
+| `src/Nova/App.php` | `wm-package` | Aggiunto HTML field `onlyOnDetail()` per `geolocation_record_enable`; Boolean wrappato con `mobileAuthDependent()->onlyOnForms()` |
+| `resources/lang/it.json` | `wm-package` | Traduzione lockMessage già presente — invariata |

--- a/docs/features/7852-gestione-automatica-parametri-app-autenticazione/plan.md
+++ b/docs/features/7852-gestione-automatica-parametri-app-autenticazione/plan.md
@@ -2,108 +2,65 @@
 
 # Plan — Gestione automatica dei parametri di App dipendenti da autenticazione
 
-## Step 1 — Verifica empirica `dependsOn` in tab annidati (PRIMA di toccare il codice)
+> **Stato finale:** `mobileAuthDependent()` mantenuto per l'edit; aggiunto HTML field per la detail view. La traduzione lockMessage rimane in `it.json`.
 
-**Obiettivo:** confermare che `dependsOn` su un `Boolean` funzioni correttamente quando entrambi i campi si trovano dentro `mobile_tab()` → `Tab::group` in Nova 5.
+## Step 1 — Aggiungere HTML field per detail view in `mobile_tab()`
 
-**Come verificare:**
+File: `src/Nova/App.php`, metodo `mobile_tab()`.
 
-Aggiungere temporaneamente un `dependsOn` di prova su `geolocation_record_enable` in `mobile_tab()`:
+Aggiungere prima del `$this->mobileAuthDependent(...)` esistente:
 
 ```php
-Boolean::make(__('Geolocation Record Enable'), 'geolocation_record_enable')
-    ->default(false)
-    ->hideFromIndex()
-    ->help(__('Enables user geolocation recording on tracks'))
-    ->dependsOn('auth_show_at_startup', function (Boolean $field, NovaRequest $request, FormData $formData) {
-        if (! $formData->boolean('auth_show_at_startup')) {
-            $field->readonly(true);
-        }
-    }),
+Text::make(__('Geolocation Record Enable'), 'geolocation_record_enable', function () {
+    $effective = $this->auth_show_at_startup && $this->geolocation_record_enable;
+
+    return $effective
+        ? '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="icon" class="w-6 h-6 text-green-500"><path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clip-rule="evenodd"/></svg>'
+        : '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="icon" class="w-6 h-6 text-red-500"><path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm-1.72 6.97a.75.75 0 1 0-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 1 0 1.06 1.06L12 13.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L13.06 12l1.72-1.72a.75.75 0 1 0-1.06-1.06L12 10.94l-1.72-1.72Z" clip-rule="evenodd"/></svg>';
+})->asHtml()->onlyOnDetail(),
 ```
 
-Aprire Nova → edit di un'App → tab Mobile → verificare:
-- `auth_show_at_startup = false` → `geolocation_record_enable` appare grayed out ✓
-- Abilitare `auth_show_at_startup` → `geolocation_record_enable` diventa editabile ✓
-
-**Se il test fallisce** (il campo non risponde): alternativa è un custom Vue component — aprire discussione con il team prima di procedere.
-
-**Se il test passa:** procedere con Step 2 (questo codice temporaneo verrà rimosso e sostituito dall'helper).
+SVG da `@heroicons/vue@2.2.0` `24/solid` — stessa libreria e dimensione (`w-6 h-6`, `viewBox="0 0 24 24"`) del `Boolean` nativo di Nova.
 
 ---
 
-## Step 2 — Aggiungere import `FormData` in `src/Nova/App.php`
+## Step 2 — Cambiare `hideFromIndex()` in `onlyOnForms()` sul Boolean esistente
 
-File: `src/Nova/App.php`
+File: `src/Nova/App.php`, metodo `mobile_tab()`.
 
-Aggiungere dopo la riga `use Laravel\Nova\Http\Requests\NovaRequest;`:
+Sul Boolean già wrappato in `mobileAuthDependent()`, cambiare:
 
 ```php
-use Laravel\Nova\Fields\FormData;
+->hideFromIndex()
 ```
+
+in:
+
+```php
+->onlyOnForms()
+```
+
+**Motivazione:** il Boolean con `hideFromIndex()` apparirebbe anche in detail view, causando duplicazione con il nuovo HTML field. `onlyOnForms()` limita il Boolean a edit/create, dove `mobileAuthDependent()` continua ad operare normalmente.
 
 ---
 
-## Step 3 — Aggiungere metodo `mobileAuthDependent()` in `src/Nova/App.php`
+## Step 3 — Verifica manuale in browser
 
-File: `src/Nova/App.php`
+Aprire Nova → detail di un'App reale → tab Mobile:
 
-Aggiungere come metodo privato nella classe `App` (posizionarlo dopo `webapp_tab()` e prima di `mobile_tab()`):
-
-```php
-private function mobileAuthDependent(Boolean $field): Boolean
-{
-    return $field->dependsOn('auth_show_at_startup', function (Boolean $field, NovaRequest $request, FormData $formData) {
-        if (! $formData->boolean('auth_show_at_startup')) {
-            $field->readonly(true);
-        }
-    });
-}
-```
+- [ ] Con `auth_show_at_startup = false`: icona rossa per `geolocation_record_enable`
+- [ ] Con `auth_show_at_startup = true` e `geolocation_record_enable = true`: icona verde
+- [ ] Con `auth_show_at_startup = true` e `geolocation_record_enable = false`: icona rossa
+- [ ] Dimensione icona uguale a quella dei Boolean nativi (es. `auth_show_at_startup`)
+- [ ] In edit: `geolocation_record_enable` appare grayed-out quando `auth_show_at_startup = false` (mobileAuthDependent attivo)
+- [ ] Salvare con qualsiasi combinazione: il valore DB non cambia per effetto di questa logica
 
 ---
 
-## Step 4 — Wrappare `geolocation_record_enable` in `mobile_tab()`
-
-File: `src/Nova/App.php`, metodo `mobile_tab()`
-
-Sostituire:
-
-```php
-Boolean::make(__('Geolocation Record Enable'), 'geolocation_record_enable')
-    ->default(false)
-    ->hideFromIndex()
-    ->help(__('Enables user geolocation recording on tracks')),
-```
-
-Con:
-
-```php
-$this->mobileAuthDependent(
-    Boolean::make(__('Geolocation Record Enable'), 'geolocation_record_enable')
-        ->default(false)
-        ->hideFromIndex()
-        ->help(__('Enables user geolocation recording on tracks'))
-),
-```
-
----
-
-## Step 5 — Verifica visiva finale in Nova
-
-Aprire Nova → edit di un'App reale → tab Mobile:
-
-- [ ] Con `auth_show_at_startup = false`: `geolocation_record_enable` è grayed out e non cliccabile
-- [ ] Con `auth_show_at_startup = true`: `geolocation_record_enable` è editabile normalmente
-- [ ] Salvare con `auth_show_at_startup = false`: il valore di `geolocation_record_enable` nel DB non cambia
-- [ ] Tab index e detail view: nessuna differenza rispetto a prima
-
----
-
-## Step 6 — Commit
+## Step 4 — Commit
 
 ```
-feat(oc:7852): add mobileAuthDependent helper to disable geolocation field when auth is off
+feat(oc:7852): add computed HTML field for geolocation display in detail view
 ```
 
 File da includere nel commit:
@@ -111,3 +68,4 @@ File da includere nel commit:
 - `docs/features/7852-gestione-automatica-parametri-app-autenticazione/overview.md`
 - `docs/features/7852-gestione-automatica-parametri-app-autenticazione/plan.md`
 - `docs/features/7852-gestione-automatica-parametri-app-autenticazione/notes.md`
+- `CLAUDE.md`

--- a/docs/features/7852-gestione-automatica-parametri-app-autenticazione/plan.md
+++ b/docs/features/7852-gestione-automatica-parametri-app-autenticazione/plan.md
@@ -1,0 +1,113 @@
+> Ticket: oc:7852
+
+# Plan — Gestione automatica dei parametri di App dipendenti da autenticazione
+
+## Step 1 — Verifica empirica `dependsOn` in tab annidati (PRIMA di toccare il codice)
+
+**Obiettivo:** confermare che `dependsOn` su un `Boolean` funzioni correttamente quando entrambi i campi si trovano dentro `mobile_tab()` → `Tab::group` in Nova 5.
+
+**Come verificare:**
+
+Aggiungere temporaneamente un `dependsOn` di prova su `geolocation_record_enable` in `mobile_tab()`:
+
+```php
+Boolean::make(__('Geolocation Record Enable'), 'geolocation_record_enable')
+    ->default(false)
+    ->hideFromIndex()
+    ->help(__('Enables user geolocation recording on tracks'))
+    ->dependsOn('auth_show_at_startup', function (Boolean $field, NovaRequest $request, FormData $formData) {
+        if (! $formData->boolean('auth_show_at_startup')) {
+            $field->readonly(true);
+        }
+    }),
+```
+
+Aprire Nova → edit di un'App → tab Mobile → verificare:
+- `auth_show_at_startup = false` → `geolocation_record_enable` appare grayed out ✓
+- Abilitare `auth_show_at_startup` → `geolocation_record_enable` diventa editabile ✓
+
+**Se il test fallisce** (il campo non risponde): alternativa è un custom Vue component — aprire discussione con il team prima di procedere.
+
+**Se il test passa:** procedere con Step 2 (questo codice temporaneo verrà rimosso e sostituito dall'helper).
+
+---
+
+## Step 2 — Aggiungere import `FormData` in `src/Nova/App.php`
+
+File: `src/Nova/App.php`
+
+Aggiungere dopo la riga `use Laravel\Nova\Http\Requests\NovaRequest;`:
+
+```php
+use Laravel\Nova\Fields\FormData;
+```
+
+---
+
+## Step 3 — Aggiungere metodo `mobileAuthDependent()` in `src/Nova/App.php`
+
+File: `src/Nova/App.php`
+
+Aggiungere come metodo privato nella classe `App` (posizionarlo dopo `webapp_tab()` e prima di `mobile_tab()`):
+
+```php
+private function mobileAuthDependent(Boolean $field): Boolean
+{
+    return $field->dependsOn('auth_show_at_startup', function (Boolean $field, NovaRequest $request, FormData $formData) {
+        if (! $formData->boolean('auth_show_at_startup')) {
+            $field->readonly(true);
+        }
+    });
+}
+```
+
+---
+
+## Step 4 — Wrappare `geolocation_record_enable` in `mobile_tab()`
+
+File: `src/Nova/App.php`, metodo `mobile_tab()`
+
+Sostituire:
+
+```php
+Boolean::make(__('Geolocation Record Enable'), 'geolocation_record_enable')
+    ->default(false)
+    ->hideFromIndex()
+    ->help(__('Enables user geolocation recording on tracks')),
+```
+
+Con:
+
+```php
+$this->mobileAuthDependent(
+    Boolean::make(__('Geolocation Record Enable'), 'geolocation_record_enable')
+        ->default(false)
+        ->hideFromIndex()
+        ->help(__('Enables user geolocation recording on tracks'))
+),
+```
+
+---
+
+## Step 5 — Verifica visiva finale in Nova
+
+Aprire Nova → edit di un'App reale → tab Mobile:
+
+- [ ] Con `auth_show_at_startup = false`: `geolocation_record_enable` è grayed out e non cliccabile
+- [ ] Con `auth_show_at_startup = true`: `geolocation_record_enable` è editabile normalmente
+- [ ] Salvare con `auth_show_at_startup = false`: il valore di `geolocation_record_enable` nel DB non cambia
+- [ ] Tab index e detail view: nessuna differenza rispetto a prima
+
+---
+
+## Step 6 — Commit
+
+```
+feat(oc:7852): add mobileAuthDependent helper to disable geolocation field when auth is off
+```
+
+File da includere nel commit:
+- `src/Nova/App.php`
+- `docs/features/7852-gestione-automatica-parametri-app-autenticazione/overview.md`
+- `docs/features/7852-gestione-automatica-parametri-app-autenticazione/plan.md`
+- `docs/features/7852-gestione-automatica-parametri-app-autenticazione/notes.md`

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -293,6 +293,6 @@
     "URL template for the tile server (e.g. https://example.com/{z}/{x}/{y}.png)": "Template URL per il server delle tile (es. https://example.com/{z}/{x}/{y}.png)",
     "Link used over the attribution tag in the app (optional)": "Link usato sul tag di attribution nell'app (opzionale)",
     "Where": "Luogo",
-    "Wheres": "Luoghi"
+    "Wheres": "Luoghi",
     "Requires authentication at startup to be enabled": "Richiede che l'autenticazione all'avvio sia attiva"
 }

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -294,4 +294,5 @@
     "Link used over the attribution tag in the app (optional)": "Link usato sul tag di attribution nell'app (opzionale)",
     "Where": "Luogo",
     "Wheres": "Luoghi"
+    "Requires authentication at startup to be enabled": "Richiede che l'autenticazione all'avvio sia attiva"
 }

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -10,6 +10,7 @@ use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\Code;
 use Laravel\Nova\Fields\Color;
+use Laravel\Nova\Fields\FormData;
 use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Number;
@@ -206,6 +207,17 @@ class App extends Resource
         ];
     }
 
+    private function mobileAuthDependent(Boolean $field): Boolean
+    {
+        return $field->dependsOn('auth_show_at_startup', function (Boolean $field, NovaRequest $request, FormData $formData) {
+            if (! $formData->boolean('auth_show_at_startup')) {
+                $lockMessage = __('Requires authentication at startup to be enabled');
+                $field->readonly(true)
+                    ->help(implode(' — ', array_filter([$field->helpText, $lockMessage])));
+            }
+        });
+    }
+
     protected function mobile_tab(): array
     {
         return [
@@ -218,10 +230,12 @@ class App extends Resource
                 ->default(false)
                 ->hideFromIndex()
                 ->help(__('Shows the authentication and registration page for users')),
-            Boolean::make(__('Geolocation Record Enable'), 'geolocation_record_enable')
-                ->default(false)
-                ->hideFromIndex()
-                ->help(__('Enables user geolocation recording on tracks')),
+            $this->mobileAuthDependent(
+                Boolean::make(__('Geolocation Record Enable'), 'geolocation_record_enable')
+                    ->default(false)
+                    ->hideFromIndex()
+                    ->help(__('Enables user geolocation recording on tracks'))
+            ),
             Boolean::make(__('Show Download Tiles'), 'properties->show_download_tiles')
                 ->default(false)
                 ->hideFromIndex()

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -230,10 +230,17 @@ class App extends Resource
                 ->default(false)
                 ->hideFromIndex()
                 ->help(__('Shows the authentication and registration page for users')),
+            Text::make(__('Geolocation Record Enable'), 'geolocation_record_enable', function () {
+                $effective = $this->auth_show_at_startup && $this->geolocation_record_enable;
+
+                return $effective
+                    ? '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="icon" class="w-6 h-6 text-green-500"><path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z" clip-rule="evenodd"/></svg>'
+                    : '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" data-slot="icon" class="w-6 h-6 text-red-500"><path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm-1.72 6.97a.75.75 0 1 0-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 1 0 1.06 1.06L12 13.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L13.06 12l1.72-1.72a.75.75 0 1 0-1.06-1.06L12 10.94l-1.72-1.72Z" clip-rule="evenodd"/></svg>';
+            })->asHtml()->onlyOnDetail(),
             $this->mobileAuthDependent(
                 Boolean::make(__('Geolocation Record Enable'), 'geolocation_record_enable')
                     ->default(false)
-                    ->hideFromIndex()
+                    ->onlyOnForms()
                     ->help(__('Enables user geolocation recording on tracks'))
             ),
             Boolean::make(__('Show Download Tiles'), 'properties->show_download_tiles')


### PR DESCRIPTION
## Summary

- Aggiunge il metodo privato `mobileAuthDependent(Boolean $field): Boolean` in `src/Nova/App.php` che graya-out `geolocation_record_enable` tramite `->readonly(true)` + help text concatenato quando `auth_show_at_startup` è `false`
- Comportamento puramente visivo: nessuna modifica al DB, nessuna logica nell'observer
- Aggiunta traduzione italiana in `resources/lang/it.json`

## Test plan

- [ ] Nova → edit di un'App → tab Mobile: con `auth_show_at_startup = false`, `geolocation_record_enable` appare grayed out con help text "Abilita la registrazione della geolocalizzazione utente sulle tracce — Richiede che l'autenticazione all'avvio sia attiva"
- [ ] Abilitare `auth_show_at_startup` → `geolocation_record_enable` torna editabile
- [ ] Salvare con `auth_show_at_startup = false`: il valore di `geolocation_record_enable` nel DB non cambia
- [ ] Detail view e index: nessuna regressione

🤖 Generated with [Claude Code](https://claude.com/claude-code)