### PR TITLE
feat(nova): ✨ add role modification capability in Nova user resource OC:8072

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ protected static function newFactory(): Factory
 | Fix getTaxonomyMorphableRecords | oc:8013 | `src/Jobs/Import/ImportTaxonomyJob.php` | Corregge il parametro passato a getTaxonomyMorphableRecords: entityId (GeoHub) invece di model->id (Maphub) |
 | Refactor SuperAdminService | oc:8006 | `src/Services/RolesAndPermissionsService.php`, `src/Support/SuperAdminService.php` (rimosso), `src/Nova/App.php`, `src/Nova/Actions/GenerateAppIconsAction.php`, `src/Nova/Actions/BuildAppPoisGeojsonAction.php`, `src/Policies/AppPolicy.php` | Sposta i check super-admin email-based in RolesAndPermissionsService; rimuove SuperAdminService |
 | Fix esposizione assets API | oc:7913 | `src/Http/Controllers/Api/AppController.php` | `getOrDownloadIcon` usa `getMedia()->first()` invece di `isset($app->$type)` — fix 404 su app con media in Spatie e colonne null |
+| Modifica ruolo utente in Nova | oc:8072 | `src/Nova/AbstractUserResource.php`, `tests/Feature/Nova/AbstractUserResourceRoleGuardTest.php` | Guard `RolesAndPermissionsService::allowsUser()` su ruoli/permessi; fillUsing server-side; anti-self-demotion |
 
 ## Decisioni architetturali
 
@@ -80,6 +81,13 @@ protected static function newFactory(): Factory
 - `getOrDownloadIcon` usa `getMedia($type)->first()` come unica fonte di verità — `isset($app->$type)` controllava la colonna DB che su Maphub è sempre null (upload via Spatie Media Library)
 - Nessun fallback sulla colonna: app che hanno solo la colonna valorizzata (senza media in Spatie) ricevono 404 — comportamento atteso e diagnosticabile
 - `getCustomProperty('mime-type')` può restituire null (custom property non salvata al caricamento); il campo nativo corretto è `$mediaItem->mime_type` — fix separato tracciato in oc:8122
+
+### Modifica ruolo utente in Nova (oc:8072)
+- `RoleBooleanGroup` e `PermissionBooleanGroup` in `AbstractUserResource` usano `RolesAndPermissionsService::allowsUser()` come guard — nessuna email hardcodata
+- `fillUsing()` server-side su entrambi i campi: blocca la persistenza se `allowsUser()` restituisce `false` — il guard non è solo visivo
+- Anti-self-demotion: `fillUsing` di `RoleBooleanGroup` forza il ruolo Administrator nell'utente corrente se sta modificando se stesso
+- Il package NON gestisce `hideFromIndex()` — ogni progetto deve farlo tramite override `fields()` in `User.php`
+- `PermissionBooleanGroup` usa `dependsOn('roles')` per mostrare solo i permessi rilevanti (es. `validate %` per Validator, `manage roles and permissions` per Administrator)
 
 ### EC POI map icon display (oc:7645)
 - `show_image_on_map` salvato in `properties` JSON di `EcPoi` — nessuna migration, il modello ha già il campo `properties` (jsonb)

--- a/docs/features/8072-modifica-ruolo-utente-nova/notes.md
+++ b/docs/features/8072-modifica-ruolo-utente-nova/notes.md
@@ -12,6 +12,15 @@
 - **`$editor` → `$nonSuperAdmin`**: la variabile rappresentava un Administrator generico, non un Editor. Rinominata per chiarezza.
 - **`PermissionBooleanGroup` incluso**: ruolo e permessi sono logicamente inseparabili in Spatie. Il `dependsOn` mostra solo i permessi rilevanti per i ruoli selezionati (es. `validate %` per Validator, `manage roles and permissions` per Administrator).
 
+## Bug trovati in code review
+
+- **`json_decode` null → `syncRoles([])`**: payload JSON malformato causava azzeramento silenzioso di tutti i ruoli/permessi. Fix: return early se `is_array($decoded)` è `false`.
+- **Anti-self-demotion assegnava Administrator a chi non lo aveva**: la condizione `$request->user()->id === $model->id` senza check su `$model->hasRole('Administrator')` assegnava il ruolo Administrator a qualsiasi super-admin che si modificava, anche senza averlo nel DB. Fix: aggiunta condizione `&& $model->hasRole('Administrator')`.
+- **`PermissionBooleanGroup.fillUsing` senza protezione self-edit**: un super-admin poteva rimuovere i propri permessi diretti (es. `manage roles and permissions`) senza alcun blocco. Fix: se `$request->user()->id === $model->id`, i permessi esistenti vengono preservati tramite merge.
+- **Sorgente auth inconsistente**: `readonly()` e `canSee()` usavano `auth()->user()`, mentre `fillUsing()` usava `$request->user()`. Fix: allineati tutti a `$request->user()`.
+- **Helper test nel namespace globale**: `makeUserResource()` e `makeRoleField()` dichiarate come funzioni PHP globali — rischio `Cannot redeclare` in ambienti paralleli. Fix: convertite in closure file-scoped catturate con `use`.
+
 ## Follow-up
 
 - **Override `hideFromIndex()` in ogni shard**: i campi `RoleBooleanGroup` e `PermissionBooleanGroup` ereditati da `AbstractUserResource` appaiono come colonne nell'index Nova. Ogni progetto che estende `AbstractUserResource` deve fare l'override di `fields()` in `User.php` per aggiungere `hideFromIndex()` su entrambi i campi (vedi implementazione in maphub `app/Nova/User.php`). Se non fatto, le colonne Ruoli e Permessi saranno visibili nella lista utenti.
+- **`dependsOn` hardcoda Administrator e Validator**: ruoli custom non vedono i loro permessi nel `PermissionBooleanGroup`. Tech debt noto, fuori scope — se il progetto introduce ruoli custom con permessi, il `dependsOn` va reso dinamico.

--- a/docs/features/8072-modifica-ruolo-utente-nova/notes.md
+++ b/docs/features/8072-modifica-ruolo-utente-nova/notes.md
@@ -1,0 +1,17 @@
+> Ticket: oc:8072
+
+# Notes — Modifica ruolo utente Nova (wm-package)
+
+## Deviazioni dal piano
+
+- **Nome file test**: il piano prevedeva `AbstractUserResourceTest.php`; il file effettivo è `AbstractUserResourceRoleGuardTest.php` per rendere esplicito lo scopo.
+
+## Decisioni
+
+- **`Editor` → `Validator` nei test**: il ruolo `Editor` non è creato da `seedDatabase()`. Usare `Validator` rende i test autocontenuti senza seed aggiuntivi.
+- **`$editor` → `$nonSuperAdmin`**: la variabile rappresentava un Administrator generico, non un Editor. Rinominata per chiarezza.
+- **`PermissionBooleanGroup` incluso**: ruolo e permessi sono logicamente inseparabili in Spatie. Il `dependsOn` mostra solo i permessi rilevanti per i ruoli selezionati (es. `validate %` per Validator, `manage roles and permissions` per Administrator).
+
+## Follow-up
+
+- **Override `hideFromIndex()` in ogni shard**: i campi `RoleBooleanGroup` e `PermissionBooleanGroup` ereditati da `AbstractUserResource` appaiono come colonne nell'index Nova. Ogni progetto che estende `AbstractUserResource` deve fare l'override di `fields()` in `User.php` per aggiungere `hideFromIndex()` su entrambi i campi (vedi implementazione in maphub `app/Nova/User.php`). Se non fatto, le colonne Ruoli e Permessi saranno visibili nella lista utenti.

--- a/docs/features/8072-modifica-ruolo-utente-nova/overview.md
+++ b/docs/features/8072-modifica-ruolo-utente-nova/overview.md
@@ -12,15 +12,19 @@ La logica precedente accoppiava il guard ai ruoli Spatie. `RolesAndPermissionsSe
 
 ## Requisiti
 
-- [x] `RoleBooleanGroup` e `PermissionBooleanGroup` usano `RolesAndPermissionsService::allowsUser(auth()->user())` come guard `readonly`
+- [x] `RoleBooleanGroup` e `PermissionBooleanGroup` usano `RolesAndPermissionsService::allowsUser($request->user())` come guard `readonly` (sorgente auth allineata a `fillUsing`)
 - [x] Protezione server-side via `fillUsing()`: se `allowsUser()` restituisce `false`, il payload viene ignorato e non persiste nel DB
-- [x] Anti-self-demotion: `fillUsing` di `RoleBooleanGroup` impedisce di rimuovere il ruolo Administrator dall'utente corrente
+- [x] `fillUsing` di entrambi i campi esegue return early se `json_decode` restituisce un non-array (JSON malformato non azzera ruoli/permessi)
+- [x] Anti-self-demotion `RoleBooleanGroup`: impedisce di rimuovere il ruolo Administrator dall'utente corrente **solo se lo aveva già nel DB**
+- [x] Anti-self-demotion `PermissionBooleanGroup`: un super-admin che modifica se stesso non può rimuovere i propri permessi diretti esistenti
+- [x] `canSee()` sulle `HasMany` usa `$request->user()` per coerenza con il resto della logica auth
 - [x] Nessuna email hardcodata in `AbstractUserResource`
 - [x] `PermissionBooleanGroup` contestuale ai ruoli selezionati tramite `dependsOn`
 
 ## Rischi
 
 - **Breaking change per shard che dipendevano dal guard Administrator**: altri progetti che si aspettavano che gli Administrator potessero modificare i ruoli vedranno i campi diventare readonly. Comportamento intenzionale — la modifica è limitata ai super-admin configurati via `WM_SUPER_ADMIN_EMAILS`.
+- **Anti-self-demotion permessi conservativa**: un super-admin non può rimuovere i propri permessi diretti. Se serve una revoca esplicita dei propri permessi, va fatta via CLI o tinker.
 
 ## Out of scope
 

--- a/docs/features/8072-modifica-ruolo-utente-nova/overview.md
+++ b/docs/features/8072-modifica-ruolo-utente-nova/overview.md
@@ -1,0 +1,35 @@
+> Ticket: oc:8072
+
+# Aggiungere in Nova la possibilità di modificare il ruolo di un utente — wm-package
+
+## Cosa cambia
+
+`AbstractUserResource` aggiunge guard e protezione server-side sui campi `RoleBooleanGroup` e `PermissionBooleanGroup`. Il guard usa `RolesAndPermissionsService::allowsUser()` invece di controllare direttamente i ruoli Spatie. La modifica è trasversale a tutti i progetti che usano il package.
+
+## Perché
+
+La logica precedente accoppiava il guard ai ruoli Spatie. `RolesAndPermissionsService` è già il punto centralizzato per la decisione di accesso super-admin — il guard deve solo consumarlo.
+
+## Requisiti
+
+- [x] `RoleBooleanGroup` e `PermissionBooleanGroup` usano `RolesAndPermissionsService::allowsUser(auth()->user())` come guard `readonly`
+- [x] Protezione server-side via `fillUsing()`: se `allowsUser()` restituisce `false`, il payload viene ignorato e non persiste nel DB
+- [x] Anti-self-demotion: `fillUsing` di `RoleBooleanGroup` impedisce di rimuovere il ruolo Administrator dall'utente corrente
+- [x] Nessuna email hardcodata in `AbstractUserResource`
+- [x] `PermissionBooleanGroup` contestuale ai ruoli selezionati tramite `dependsOn`
+
+## Rischi
+
+- **Breaking change per shard che dipendevano dal guard Administrator**: altri progetti che si aspettavano che gli Administrator potessero modificare i ruoli vedranno i campi diventare readonly. Comportamento intenzionale — la modifica è limitata ai super-admin configurati via `WM_SUPER_ADMIN_EMAILS`.
+
+## Out of scope
+
+- Modifica di `RolesAndPermissionsService` (solo consumo)
+- Visibilità dei campi nell'index (gestita nei singoli progetti tramite override)
+
+## Moduli toccati
+
+| File | Tipo modifica |
+|------|---------------|
+| `src/Nova/AbstractUserResource.php` | Guard `readonly` + `fillUsing()` + anti-self-demotion |
+| `tests/Feature/Nova/AbstractUserResourceRoleGuardTest.php` | Nuovo test |

--- a/docs/features/8072-modifica-ruolo-utente-nova/plan.md
+++ b/docs/features/8072-modifica-ruolo-utente-nova/plan.md
@@ -27,3 +27,37 @@ Test Pest che copre:
 - Super-admin può modificare il ruolo Administrator di un altro utente
 
 **Commit:** `test(oc:8072): add feature tests for AbstractUserResource role guard`
+
+---
+
+## Task 3 — Fix bug bloccanti da code review
+
+**File:** `src/Nova/AbstractUserResource.php`
+
+### 3a — Return early su JSON non-array in `fillUsing` (Bug #1)
+Aggiunto check `is_array($decoded)` dopo `json_decode` in entrambi i `fillUsing`. Se il payload è JSON malformato o non-array, la funzione esce senza toccare ruoli/permessi.
+
+### 3b — Anti-self-demotion condizionata a `$model->hasRole('Administrator')` (Bug #2)
+La protezione ora scatta solo se il modello aveva già il ruolo Administrator nel DB. Prima assegnava Administrator a chiunque si modificasse da solo, anche senza averlo mai avuto.
+
+### 3c — `PermissionBooleanGroup.fillUsing` protegge i permessi in self-edit (Bug #3)
+Aggiunta protezione simmetrica a quella dei ruoli: se `$request->user()->id === $model->id`, i permessi diretti esistenti vengono preservati tramite merge.
+
+### 3d — Sorgente auth allineata a `$request->user()` in `readonly()` e `canSee()` (Cleanup)
+`readonly()` su entrambi i campi e `canSee()` sulle `HasMany` usano ora `$request->user()` invece di `auth()->user()` — coerente con `fillUsing` e corretto in contesti headless/test.
+
+**Commit:** `fix(oc:8072): fix json guard, anti-self-demotion, permission protection and align auth sources`
+
+---
+
+## Task 4 — Aggiornare test
+
+**File:** `tests/Feature/Nova/AbstractUserResourceRoleGuardTest.php`
+
+- Helper `makeUserResource()` e `makeRoleField()` convertiti da funzioni globali a closure file-scoped (previene `Cannot redeclare` in test paralleli)
+- Aggiunto `makePermissionField` closure
+- Aggiunti test per i bug fix: JSON invalido (roles e permissions), anti-self-demotion senza ruolo preesistente, guard `PermissionBooleanGroup` per non-super-admin e super-admin, protezione self-edit permessi
+- Spostati da maphub i test `super-admin can assign a new role` e `super-admin can modify another users administrator role` (testano logica package, non maphub)
+- Corretto commento errato: la protezione è nel `return` dentro `fillUsing()`, non in `readonly()`
+
+**Commit:** `test(oc:8072): fix global helpers, add permission guard and bug fix tests`

--- a/docs/features/8072-modifica-ruolo-utente-nova/plan.md
+++ b/docs/features/8072-modifica-ruolo-utente-nova/plan.md
@@ -1,0 +1,29 @@
+> Ticket: oc:8072
+
+# Plan — Modifica ruolo utente Nova (wm-package)
+
+## Task 1 — Aggiornare `AbstractUserResource` ✅
+
+**File:** `src/Nova/AbstractUserResource.php`
+
+- Sostituito guard `readonly` su `RoleBooleanGroup` con `RolesAndPermissionsService::allowsUser(auth()->user())`
+- Aggiunta `fillUsing()` server-side su `RoleBooleanGroup`: blocca la persistenza se `allowsUser()` restituisce `false`; logica anti-self-demotion che impedisce di rimuovere il ruolo Administrator dall'utente corrente
+- Sostituito guard `readonly` su `PermissionBooleanGroup` con `RolesAndPermissionsService::allowsUser(auth()->user())`
+- Aggiunta `fillUsing()` server-side su `PermissionBooleanGroup`: blocca la persistenza se `allowsUser()` restituisce `false`
+- `PermissionBooleanGroup` usa `dependsOn('roles', ...)` per mostrare solo i permessi rilevanti ai ruoli selezionati
+
+**Commit:** `feat(oc:8072): use RolesAndPermissionsService as guard for role/permission fields in AbstractUserResource`
+
+---
+
+## Task 2 — Aggiungere test ✅
+
+**File:** `tests/Feature/Nova/AbstractUserResourceRoleGuardTest.php` (nuovo)
+
+Test Pest che copre:
+- Non-super-admin non può modificare ruoli (`fillUsing` è no-op, ruoli originali invariati)
+- Super-admin può assegnare un nuovo ruolo tramite `fillUsing`
+- Super-admin non può rimuovere il proprio ruolo Administrator (anti-self-demotion)
+- Super-admin può modificare il ruolo Administrator di un altro utente
+
+**Commit:** `test(oc:8072): add feature tests for AbstractUserResource role guard`

--- a/src/Nova/AbstractUserResource.php
+++ b/src/Nova/AbstractUserResource.php
@@ -19,6 +19,7 @@ use Vyuldashev\NovaPermission\PermissionBooleanGroup;
 use Vyuldashev\NovaPermission\RoleBooleanGroup;
 use Wm\WmPackage\Models\App as AppModel;
 use Wm\WmPackage\Nova\Filters\AppFilter;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
 
 abstract class AbstractUserResource extends Resource
 {
@@ -68,12 +69,44 @@ abstract class AbstractUserResource extends Resource
                 ->updateRules('nullable', Rules\Password::defaults()),
             ...array_filter([$this->getAppFieldForIndex()]),
             RoleBooleanGroup::make(__('Roles'), 'roles')
-                ->readonly(function () {
-                    return ! auth()->user()->hasRole('Administrator') && ! auth()->user()->hasPermissionTo('manage roles and permissions');
+                ->readonly(fn () => ! RolesAndPermissionsService::allowsUser(auth()->user()))
+                ->fillUsing(function (NovaRequest $request, $model, $attribute, $requestAttribute) {
+                    if (! RolesAndPermissionsService::allowsUser($request->user())) {
+                        return;
+                    }
+
+                    if (! $request->exists($requestAttribute)) {
+                        return;
+                    }
+
+                    $roles = collect(json_decode($request[$requestAttribute], true))
+                        ->filter(fn ($value) => $value)
+                        ->keys();
+
+                    // Prevent super-admin from removing their own Administrator role
+                    if ($request->user()->id === $model->id) {
+                        $roles = $roles->merge(['Administrator'])->unique();
+                    }
+
+                    $model->syncRoles($roles->toArray());
                 }),
             PermissionBooleanGroup::make(__('Permissions'), 'permissions')
-                ->readonly(function () {
-                    return ! auth()->user()->hasRole('Administrator') && ! auth()->user()->hasPermissionTo('manage roles and permissions');
+                ->readonly(fn () => ! RolesAndPermissionsService::allowsUser(auth()->user()))
+                ->fillUsing(function (NovaRequest $request, $model, $attribute, $requestAttribute) {
+                    if (! RolesAndPermissionsService::allowsUser($request->user())) {
+                        return;
+                    }
+
+                    if (! $request->exists($requestAttribute)) {
+                        return;
+                    }
+
+                    $values = collect(json_decode($request[$requestAttribute], true))
+                        ->filter(fn ($value) => $value)
+                        ->keys()
+                        ->toArray();
+
+                    $model->syncPermissions($values);
                 })
                 ->dependsOn('roles', function (PermissionBooleanGroup $field, NovaRequest $request, FormData $formData) {
                     $roles = $formData->get('roles');

--- a/src/Nova/AbstractUserResource.php
+++ b/src/Nova/AbstractUserResource.php
@@ -69,7 +69,7 @@ abstract class AbstractUserResource extends Resource
                 ->updateRules('nullable', Rules\Password::defaults()),
             ...array_filter([$this->getAppFieldForIndex()]),
             RoleBooleanGroup::make(__('Roles'), 'roles')
-                ->readonly(fn () => ! RolesAndPermissionsService::allowsUser(auth()->user()))
+                ->readonly(fn (NovaRequest $request) => ! RolesAndPermissionsService::allowsUser($request->user()))
                 ->fillUsing(function (NovaRequest $request, $model, $attribute, $requestAttribute) {
                     if (! RolesAndPermissionsService::allowsUser($request->user())) {
                         return;
@@ -79,19 +79,23 @@ abstract class AbstractUserResource extends Resource
                         return;
                     }
 
-                    $roles = collect(json_decode($request[$requestAttribute], true))
+                    $decoded = json_decode($request[$requestAttribute], true);
+                    if (! is_array($decoded)) {
+                        return;
+                    }
+
+                    $roles = collect($decoded)
                         ->filter(fn ($value) => $value)
                         ->keys();
 
-                    // Prevent super-admin from removing their own Administrator role
-                    if ($request->user()->id === $model->id) {
+                    if ($request->user()->id === $model->id && $model->hasRole('Administrator')) {
                         $roles = $roles->merge(['Administrator'])->unique();
                     }
 
                     $model->syncRoles($roles->toArray());
                 }),
             PermissionBooleanGroup::make(__('Permissions'), 'permissions')
-                ->readonly(fn () => ! RolesAndPermissionsService::allowsUser(auth()->user()))
+                ->readonly(fn (NovaRequest $request) => ! RolesAndPermissionsService::allowsUser($request->user()))
                 ->fillUsing(function (NovaRequest $request, $model, $attribute, $requestAttribute) {
                     if (! RolesAndPermissionsService::allowsUser($request->user())) {
                         return;
@@ -101,10 +105,20 @@ abstract class AbstractUserResource extends Resource
                         return;
                     }
 
-                    $values = collect(json_decode($request[$requestAttribute], true))
+                    $decoded = json_decode($request[$requestAttribute], true);
+                    if (! is_array($decoded)) {
+                        return;
+                    }
+
+                    $values = collect($decoded)
                         ->filter(fn ($value) => $value)
                         ->keys()
                         ->toArray();
+
+                    if ($request->user()->id === $model->id) {
+                        $existing = $model->getDirectPermissions()->pluck('name')->toArray();
+                        $values = array_unique(array_merge($values, $existing));
+                    }
 
                     $model->syncPermissions($values);
                 })
@@ -128,14 +142,10 @@ abstract class AbstractUserResource extends Resource
                 }),
             HasMany::make(__('UGC POIs'), 'ugc_pois', UgcPoi::class)
                 ->onlyOnDetail()
-                ->canSee(function () {
-                    return optional(auth()->user())->hasRole('Administrator');
-                }),
+                ->canSee(fn (NovaRequest $request) => optional($request->user())->hasRole('Administrator')),
             HasMany::make(__('UGC Tracks'), 'ugc_tracks', UgcTrack::class)
                 ->onlyOnDetail()
-                ->canSee(function () {
-                    return optional(auth()->user())->hasRole('Administrator');
-                }),
+                ->canSee(fn (NovaRequest $request) => optional($request->user())->hasRole('Administrator')),
         ];
     }
 

--- a/src/Nova/Filters/FormSchemaFilter.php
+++ b/src/Nova/Filters/FormSchemaFilter.php
@@ -60,7 +60,7 @@ class FormSchemaFilter extends Filter
         foreach ($allApps as $app) {
             $acquisition_form = $this->type instanceof UgcPoi ? $app->poi_acquisition_form : $app->track_acquisition_form;
             $schemas = json_decode($acquisition_form, true);
-            foreach ($schemas as $schema) {
+            foreach ($schemas ?? [] as $schema) {
                 $label = reset($schema['label']);
                 // Salta se il label è vuoto per evitare chiavi vuote
                 if (! empty($label)) {

--- a/tests/Feature/Nova/AbstractUserResourceRoleGuardTest.php
+++ b/tests/Feature/Nova/AbstractUserResourceRoleGuardTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Auth;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Vyuldashev\NovaPermission\RoleBooleanGroup;
+use Wm\WmPackage\Models\User;
+use Wm\WmPackage\Nova\AbstractUserResource;
+use Wm\WmPackage\Services\RolesAndPermissionsService;
+
+// Minimal concrete implementation for testing
+function makeUserResource(User $user): AbstractUserResource
+{
+    return new class($user) extends AbstractUserResource
+    {
+        public static string $model = User::class;
+    };
+}
+
+function makeRoleField(NovaRequest $request, User $contextUser): RoleBooleanGroup
+{
+    Auth::login($contextUser);
+    $resource = makeUserResource($contextUser);
+    $fields = $resource->fields($request);
+
+    return collect($fields)->first(fn ($f) => $f instanceof RoleBooleanGroup);
+}
+
+beforeEach(function () {
+    config(['wm-package.super_admin_emails' => ['superadmin@test.com']]);
+
+    RolesAndPermissionsService::seedDatabase();
+});
+
+it('non-super-admin cannot modify roles via fillUsing (field is readonly)', function () {
+    $nonSuperAdmin = User::factory()->create(['email' => 'admin@test.com']);
+    $nonSuperAdmin->assignRole('Administrator');
+
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('Validator');
+
+    $request = NovaRequest::create('/', 'POST', [
+        'roles' => json_encode(['Administrator' => true, 'Validator' => false]),
+    ]);
+    $request->setUserResolver(fn () => $nonSuperAdmin);
+
+    Auth::login($nonSuperAdmin);
+    $field = makeRoleField($request, $nonSuperAdmin);
+
+    // fill() returns early when isReadonly() is true for non-super-admin
+    $field->fill($request, $targetUser);
+    $targetUser->refresh();
+
+    expect($targetUser->hasRole('Validator'))->toBeTrue()
+        ->and($targetUser->hasRole('Administrator'))->toBeFalse();
+});
+
+it('super-admin can assign a new role via fillUsing', function () {
+    $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
+    $superAdmin->assignRole('Administrator');
+
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('Validator');
+
+    $request = NovaRequest::create('/', 'POST', [
+        'roles' => json_encode(['Administrator' => true, 'Validator' => false]),
+    ]);
+    $request->setUserResolver(fn () => $superAdmin);
+
+    Auth::login($superAdmin);
+    $field = makeRoleField($request, $superAdmin);
+
+    $field->fill($request, $targetUser);
+    $targetUser->refresh();
+
+    expect($targetUser->hasRole('Administrator'))->toBeTrue()
+        ->and($targetUser->hasRole('Validator'))->toBeFalse();
+});
+
+it('super-admin cannot remove their own Administrator role (anti-self-demotion)', function () {
+    $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
+    $superAdmin->assignRole('Administrator');
+
+    // Super-admin tries to remove their own Administrator role
+    $request = NovaRequest::create('/', 'POST', [
+        'roles' => json_encode(['Administrator' => false, 'Validator' => true]),
+    ]);
+    $request->setUserResolver(fn () => $superAdmin);
+
+    Auth::login($superAdmin);
+    $field = makeRoleField($request, $superAdmin);
+
+    $field->fill($request, $superAdmin);
+    $superAdmin->refresh();
+
+    expect($superAdmin->hasRole('Administrator'))->toBeTrue();
+});
+
+it('super-admin can modify another users administrator role', function () {
+    $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
+    $superAdmin->assignRole('Administrator');
+
+    $otherAdmin = User::factory()->create();
+    $otherAdmin->assignRole('Administrator');
+
+    // Super-admin removes Administrator from another user — allowed
+    $request = NovaRequest::create('/', 'POST', [
+        'roles' => json_encode(['Administrator' => false, 'Validator' => true]),
+    ]);
+    $request->setUserResolver(fn () => $superAdmin);
+
+    Auth::login($superAdmin);
+    $field = makeRoleField($request, $superAdmin);
+
+    $field->fill($request, $otherAdmin);
+    $otherAdmin->refresh();
+
+    expect($otherAdmin->hasRole('Administrator'))->toBeFalse()
+        ->and($otherAdmin->hasRole('Validator'))->toBeTrue();
+});

--- a/tests/Feature/Nova/AbstractUserResourceRoleGuardTest.php
+++ b/tests/Feature/Nova/AbstractUserResourceRoleGuardTest.php
@@ -4,28 +4,31 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Auth;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Vyuldashev\NovaPermission\PermissionBooleanGroup;
 use Vyuldashev\NovaPermission\RoleBooleanGroup;
 use Wm\WmPackage\Models\User;
 use Wm\WmPackage\Nova\AbstractUserResource;
 use Wm\WmPackage\Services\RolesAndPermissionsService;
 
-// Minimal concrete implementation for testing
-function makeUserResource(User $user): AbstractUserResource
-{
-    return new class($user) extends AbstractUserResource
-    {
-        public static string $model = User::class;
-    };
-}
+$makeUserResource = fn (User $user): AbstractUserResource => new class($user) extends AbstractUserResource {
+    public static string $model = User::class;
+};
 
-function makeRoleField(NovaRequest $request, User $contextUser): RoleBooleanGroup
-{
+$makeRoleField = function (NovaRequest $request, User $contextUser) use ($makeUserResource): RoleBooleanGroup {
     Auth::login($contextUser);
-    $resource = makeUserResource($contextUser);
+    $resource = $makeUserResource($contextUser);
     $fields = $resource->fields($request);
 
     return collect($fields)->first(fn ($f) => $f instanceof RoleBooleanGroup);
-}
+};
+
+$makePermissionField = function (NovaRequest $request, User $contextUser) use ($makeUserResource): PermissionBooleanGroup {
+    Auth::login($contextUser);
+    $resource = $makeUserResource($contextUser);
+    $fields = $resource->fields($request);
+
+    return collect($fields)->first(fn ($f) => $f instanceof PermissionBooleanGroup);
+};
 
 beforeEach(function () {
     config(['wm-package.super_admin_emails' => ['superadmin@test.com']]);
@@ -33,7 +36,9 @@ beforeEach(function () {
     RolesAndPermissionsService::seedDatabase();
 });
 
-it('non-super-admin cannot modify roles via fillUsing (field is readonly)', function () {
+// --- RoleBooleanGroup ---
+
+it('non-super-admin cannot modify roles via fillUsing', function () use ($makeRoleField) {
     $nonSuperAdmin = User::factory()->create(['email' => 'admin@test.com']);
     $nonSuperAdmin->assignRole('Administrator');
 
@@ -45,10 +50,9 @@ it('non-super-admin cannot modify roles via fillUsing (field is readonly)', func
     ]);
     $request->setUserResolver(fn () => $nonSuperAdmin);
 
-    Auth::login($nonSuperAdmin);
-    $field = makeRoleField($request, $nonSuperAdmin);
+    $field = $makeRoleField($request, $nonSuperAdmin);
 
-    // fill() returns early when isReadonly() is true for non-super-admin
+    // Protection is the early return inside fillUsing() when allowsUser() returns false
     $field->fill($request, $targetUser);
     $targetUser->refresh();
 
@@ -56,7 +60,7 @@ it('non-super-admin cannot modify roles via fillUsing (field is readonly)', func
         ->and($targetUser->hasRole('Administrator'))->toBeFalse();
 });
 
-it('super-admin can assign a new role via fillUsing', function () {
+it('super-admin can assign a new role via fillUsing', function () use ($makeRoleField) {
     $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
     $superAdmin->assignRole('Administrator');
 
@@ -68,8 +72,7 @@ it('super-admin can assign a new role via fillUsing', function () {
     ]);
     $request->setUserResolver(fn () => $superAdmin);
 
-    Auth::login($superAdmin);
-    $field = makeRoleField($request, $superAdmin);
+    $field = $makeRoleField($request, $superAdmin);
 
     $field->fill($request, $targetUser);
     $targetUser->refresh();
@@ -78,18 +81,16 @@ it('super-admin can assign a new role via fillUsing', function () {
         ->and($targetUser->hasRole('Validator'))->toBeFalse();
 });
 
-it('super-admin cannot remove their own Administrator role (anti-self-demotion)', function () {
+it('super-admin cannot remove their own Administrator role (anti-self-demotion)', function () use ($makeRoleField) {
     $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
     $superAdmin->assignRole('Administrator');
 
-    // Super-admin tries to remove their own Administrator role
     $request = NovaRequest::create('/', 'POST', [
         'roles' => json_encode(['Administrator' => false, 'Validator' => true]),
     ]);
     $request->setUserResolver(fn () => $superAdmin);
 
-    Auth::login($superAdmin);
-    $field = makeRoleField($request, $superAdmin);
+    $field = $makeRoleField($request, $superAdmin);
 
     $field->fill($request, $superAdmin);
     $superAdmin->refresh();
@@ -97,25 +98,139 @@ it('super-admin cannot remove their own Administrator role (anti-self-demotion)'
     expect($superAdmin->hasRole('Administrator'))->toBeTrue();
 });
 
-it('super-admin can modify another users administrator role', function () {
+it('super-admin can modify another users administrator role', function () use ($makeRoleField) {
     $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
     $superAdmin->assignRole('Administrator');
 
     $otherAdmin = User::factory()->create();
     $otherAdmin->assignRole('Administrator');
 
-    // Super-admin removes Administrator from another user — allowed
     $request = NovaRequest::create('/', 'POST', [
         'roles' => json_encode(['Administrator' => false, 'Validator' => true]),
     ]);
     $request->setUserResolver(fn () => $superAdmin);
 
-    Auth::login($superAdmin);
-    $field = makeRoleField($request, $superAdmin);
+    $field = $makeRoleField($request, $superAdmin);
 
     $field->fill($request, $otherAdmin);
     $otherAdmin->refresh();
 
     expect($otherAdmin->hasRole('Administrator'))->toBeFalse()
         ->and($otherAdmin->hasRole('Validator'))->toBeTrue();
+});
+
+it('anti-self-demotion does not assign Administrator to super-admin who never had it', function () use ($makeRoleField) {
+    $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
+
+    $request = NovaRequest::create('/', 'POST', [
+        'roles' => json_encode(['Validator' => true]),
+    ]);
+    $request->setUserResolver(fn () => $superAdmin);
+
+    $field = $makeRoleField($request, $superAdmin);
+
+    $field->fill($request, $superAdmin);
+    $superAdmin->refresh();
+
+    expect($superAdmin->hasRole('Administrator'))->toBeFalse()
+        ->and($superAdmin->hasRole('Validator'))->toBeTrue();
+});
+
+it('fillUsing returns early on invalid JSON without wiping roles', function () use ($makeRoleField) {
+    $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
+    $superAdmin->assignRole('Administrator');
+
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('Validator');
+
+    $request = NovaRequest::create('/', 'POST', [
+        'roles' => 'not-valid-json',
+    ]);
+    $request->setUserResolver(fn () => $superAdmin);
+
+    $field = $makeRoleField($request, $superAdmin);
+
+    $field->fill($request, $targetUser);
+    $targetUser->refresh();
+
+    expect($targetUser->hasRole('Validator'))->toBeTrue();
+});
+
+// --- PermissionBooleanGroup ---
+
+it('non-super-admin cannot modify permissions via fillUsing', function () use ($makePermissionField) {
+    $nonSuperAdmin = User::factory()->create(['email' => 'admin@test.com']);
+    $nonSuperAdmin->assignRole('Administrator');
+
+    $targetUser = User::factory()->create();
+    $targetUser->assignRole('Validator');
+
+    $request = NovaRequest::create('/', 'POST', [
+        'permissions' => json_encode(['validate ugc' => true]),
+    ]);
+    $request->setUserResolver(fn () => $nonSuperAdmin);
+
+    $field = $makePermissionField($request, $nonSuperAdmin);
+
+    $field->fill($request, $targetUser);
+    $targetUser->refresh();
+
+    expect($targetUser->hasDirectPermission('validate ugc'))->toBeFalse();
+});
+
+it('super-admin can assign permissions via fillUsing', function () use ($makePermissionField) {
+    $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
+    $superAdmin->assignRole('Administrator');
+
+    $targetUser = User::factory()->create();
+
+    $request = NovaRequest::create('/', 'POST', [
+        'permissions' => json_encode(['manage roles and permissions' => true]),
+    ]);
+    $request->setUserResolver(fn () => $superAdmin);
+
+    $field = $makePermissionField($request, $superAdmin);
+
+    $field->fill($request, $targetUser);
+    $targetUser->refresh();
+
+    expect($targetUser->hasDirectPermission('manage roles and permissions'))->toBeTrue();
+});
+
+it('super-admin cannot remove their own existing direct permissions', function () use ($makePermissionField) {
+    $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
+    $superAdmin->assignRole('Administrator');
+    $superAdmin->givePermissionTo('manage roles and permissions');
+
+    $request = NovaRequest::create('/', 'POST', [
+        'permissions' => json_encode(['manage roles and permissions' => false]),
+    ]);
+    $request->setUserResolver(fn () => $superAdmin);
+
+    $field = $makePermissionField($request, $superAdmin);
+
+    $field->fill($request, $superAdmin);
+    $superAdmin->refresh();
+
+    expect($superAdmin->hasDirectPermission('manage roles and permissions'))->toBeTrue();
+});
+
+it('permissions fillUsing returns early on invalid JSON without wiping permissions', function () use ($makePermissionField) {
+    $superAdmin = User::factory()->create(['email' => 'superadmin@test.com']);
+    $superAdmin->assignRole('Administrator');
+
+    $targetUser = User::factory()->create();
+    $targetUser->givePermissionTo('manage roles and permissions');
+
+    $request = NovaRequest::create('/', 'POST', [
+        'permissions' => 'not-valid-json',
+    ]);
+    $request->setUserResolver(fn () => $superAdmin);
+
+    $field = $makePermissionField($request, $superAdmin);
+
+    $field->fill($request, $targetUser);
+    $targetUser->refresh();
+
+    expect($targetUser->hasDirectPermission('manage roles and permissions'))->toBeTrue();
 });


### PR DESCRIPTION
- Introduced server-side guards using `RolesAndPermissionsService::allowsUser()` for `RoleBooleanGroup` and `PermissionBooleanGroup` in `AbstractUserResource`.
- Implemented `fillUsing()` for secure role updates, ensuring:
  - Roles are only modified if the user is allowed.
  - Super-admins cannot demote themselves by removing their own Administrator role.
- Updated `PermissionBooleanGroup` to show relevant permissions based on selected roles with `dependsOn`.
- Added comprehensive tests in `AbstractUserResourceRoleGuardTest.php` to verify:
  - Non-super-admins cannot modify roles.
  - Super-admins can assign and modify roles, but cannot remove their own Administrator role.
  - Super-admins can modify the Administrator role of others.

docs(oc:8072): 📝 add documentation for user role modification feature

- Created `notes.md` detailing deviations, decisions, and follow-up actions.
- Documented the feature overview in `overview.md`, explaining changes, rationale, requirements, risks, and modules affected.
- Added `plan.md` outlining tasks, implementation details, and associated commits for the feature enhancement.
