### PR TITLE
docs(oc:7913): 📄 add documentation for asset exposure API fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,14 @@ protected static function newFactory(): Factory
 | Dipendenza visiva auth → geolocalizzazione in Nova | oc:7852 | `src/Nova/App.php`, `resources/lang/it.json` | HTML field `onlyOnDetail()` con valore calcolato; `mobileAuthDependent()` mantiene grayed-out in edit; Boolean `onlyOnForms()` evita duplicazione in detail |
 | Fix getTaxonomyMorphableRecords | oc:8013 | `src/Jobs/Import/ImportTaxonomyJob.php` | Corregge il parametro passato a getTaxonomyMorphableRecords: entityId (GeoHub) invece di model->id (Maphub) |
 | Refactor SuperAdminService | oc:8006 | `src/Services/RolesAndPermissionsService.php`, `src/Support/SuperAdminService.php` (rimosso), `src/Nova/App.php`, `src/Nova/Actions/GenerateAppIconsAction.php`, `src/Nova/Actions/BuildAppPoisGeojsonAction.php`, `src/Policies/AppPolicy.php` | Sposta i check super-admin email-based in RolesAndPermissionsService; rimuove SuperAdminService |
+| Fix esposizione assets API | oc:7913 | `src/Http/Controllers/Api/AppController.php` | `getOrDownloadIcon` usa `getMedia()->first()` invece di `isset($app->$type)` — fix 404 su app con media in Spatie e colonne null |
 
 ## Decisioni architetturali
+
+### Fix esposizione assets API (oc:7913)
+- `getOrDownloadIcon` usa `getMedia($type)->first()` come unica fonte di verità — `isset($app->$type)` controllava la colonna DB che su Maphub è sempre null (upload via Spatie Media Library)
+- Nessun fallback sulla colonna: app che hanno solo la colonna valorizzata (senza media in Spatie) ricevono 404 — comportamento atteso e diagnosticabile
+- `getCustomProperty('mime-type')` può restituire null (custom property non salvata al caricamento); il campo nativo corretto è `$mediaItem->mime_type` — fix separato tracciato in oc:8122
 
 ### EC POI map icon display (oc:7645)
 - `show_image_on_map` salvato in `properties` JSON di `EcPoi` — nessuna migration, il modello ha già il campo `properties` (jsonb)

--- a/docs/features/7913-esposizione-assets-api-wmpackage/notes.md
+++ b/docs/features/7913-esposizione-assets-api-wmpackage/notes.md
@@ -1,0 +1,21 @@
+> Ticket: oc:7913
+
+# Notes — Esposizione assets API wm-package
+
+## Deviazioni dal piano
+
+- Test automatici non inclusi: la scrittura del test è stata valutata durante l'implementazione ma scartata. La verifica avviene manualmente (curl sull'endpoint).
+
+## Verifica locale
+
+- Il fix supera correttamente la prima guardia (`getMedia()->first()` trova il record media).
+- La risposta in locale è `404 "File not found"` (seconda guardia) perché il bucket MinIO locale (`wmfe/maphub`) contiene solo le cartelle `1` e `json` — App 2 non ha file fisici sincronizzati localmente.
+- La verifica completa del 200 richiede staging/produzione, oppure un upload dell'icona di App 2 via Nova in locale.
+
+## Decisioni
+
+- Durante l'analisi è emerso un secondo bug nello stesso metodo: `getCustomProperty('mime-type')` restituisce null perché la custom property non viene salvata al caricamento (il campo nativo Spatie è `mime_type`). Tracciato in oc:8122, non incluso in questo fix per mantenere il cambiamento minimale.
+
+## Follow-up
+
+- oc:8122 — fix `Content-Type` null in `getOrDownloadIcon` (`getCustomProperty('mime-type')` → `mime_type`)

--- a/docs/features/7913-esposizione-assets-api-wmpackage/overview.md
+++ b/docs/features/7913-esposizione-assets-api-wmpackage/overview.md
@@ -1,0 +1,38 @@
+> Ticket: oc:7913
+
+# Esposizione assets API wm-package
+
+## Cosa cambia
+
+`AppController::getOrDownloadIcon` smette di usare `isset($app->$type)` come guardia e usa invece `$app->getMedia($type)->first()`. Se il media non esiste restituisce 404; se esiste, serve il file dallo storage (S3 o locale).
+
+## Perché
+
+Quando le immagini di un'app vengono caricate tramite Spatie Media Library (via `Images::make`), le colonne `apps.icon` / `apps.splash` restano `NULL`. La guardia `isset($app->$type)` controlla la colonna, non la media library: l'endpoint risponde 404 anche quando il file esiste su S3. Il problema non è specifico di Maphub — riguarda qualsiasi app su qualsiasi shard dove le colonne non sono valorizzate ma il media è in Spatie.
+
+## Requisiti
+
+- [x] `getOrDownloadIcon` usa `$app->getMedia($type)->first()` come unica fonte di verità
+- [x] Se il media non esiste, risponde `404 Not Found`
+- [x] Se il media esiste, serve il file dallo storage (comportamento invariato rispetto al codice attuale dopo la guardia)
+- [x] Il fix si applica a tutti i tipi gestiti dal metodo: `icon`, `icon_small`, `splash`, `feature_image`, `icon_notify`, `logo_homepage`
+- [x] Nessun fallback sulla colonna DB — app non migrate ricevono 404 (comportamento atteso e diagnosticabile)
+
+## Rischi
+
+- **Regressione su altri shard:** non presente. Le app che oggi rispondono 200 (es. osm2cai2 app 1) hanno già colonna e media allineati — `getMedia()->first()` trova il record e il comportamento è invariato.
+- **Content-Type null:** il metodo usa `getCustomProperty('mime-type')` che può essere null. Tracciato in oc:8122 come fix separato, non bloccante per questo ticket.
+- **Nessun test automatico:** la verifica è manuale (curl sull'endpoint).
+- **Verifica locale limitata:** il bucket MinIO locale (`wmfe/maphub`) contiene solo le cartelle `1` e `json` — App 2 non ha file fisici sincronizzati localmente. La verifica completa del 200 richiede staging/produzione oppure un upload dell'icona via Nova in locale.
+
+## Out of scope
+
+- Fix del `Content-Type` null (`getCustomProperty('mime-type')` → `mime_type`) — tracciato in oc:8122
+- Aggiunta di `feature_image`, `icon_notify`, `logo_homepage` a `registerMediaCollections()`
+- Test automatici per `AppController`
+
+## Moduli toccati
+
+| File | Repo | Tipo modifica |
+|------|------|---------------|
+| `src/Http/Controllers/Api/AppController.php` | `wm-package` | Fix guardia in `getOrDownloadIcon` |

--- a/docs/features/7913-esposizione-assets-api-wmpackage/plan.md
+++ b/docs/features/7913-esposizione-assets-api-wmpackage/plan.md
@@ -1,0 +1,60 @@
+> Ticket: oc:7913
+
+# Plan — Esposizione assets API wm-package
+
+## Task 1 — Crea branch in wm-package
+
+```bash
+cd wm-package
+git checkout -b oc_7913
+```
+
+## Task 2 — Fix `getOrDownloadIcon` in `AppController`
+
+File: `src/Http/Controllers/Api/AppController.php`
+
+Sostituire il corpo del metodo `getOrDownloadIcon` da:
+
+```php
+protected function getOrDownloadIcon(App $app, $type = 'icon')
+{
+    if (! isset($app->$type)) {
+        return response()->json(['code' => 404, 'error' => 'Not Found'], 404);
+    }
+
+    $mediaItem = $app->getMedia($type)->first();
+    ...
+```
+
+a:
+
+```php
+protected function getOrDownloadIcon(App $app, $type = 'icon')
+{
+    $mediaItem = $app->getMedia($type)->first();
+
+    if (! $mediaItem) {
+        return response()->json(['code' => 404, 'error' => 'Not Found'], 404);
+    }
+
+    ...
+```
+
+Il resto del metodo (disk, path, readStream, response()->stream()) rimane invariato.
+
+## Task 3 — Verifica PHPStan
+
+```bash
+cd wm-package
+vendor/bin/phpstan analyse src/Http/Controllers/Api/AppController.php
+```
+
+✅ Eseguito: 13 errori trovati, tutti pre-esistenti su righe non modificate (93, 293, 365+). Nessun errore introdotto dal fix.
+
+## Task 4 — Commit in wm-package
+
+```bash
+cd wm-package
+git add src/Http/Controllers/Api/AppController.php
+git commit -m "fix(oc:7913): use getMedia() instead of isset() in getOrDownloadIcon"
+```


### PR DESCRIPTION
- Added detailed notes, overview, and implementation plan for ticket oc:7913 related to the Esposizione assets API in the wm-package.
- Documented deviations from the plan, local verification results, and follow-up actions.
- Explained the changes made in `AppController::getOrDownloadIcon` to enhance API response accuracy.
- Highlighted potential risks, out of scope items, and modules affected by the fix.
