### PR TITLE
fix(oc:8041): use geohub_id from model properties in processDependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ protected static function newFactory(): Factory
 
 ## Decisioni architetturali
 
+### Fix import POI taxonomy type (oc:8041)
+- `processDependencies()` usa `$model->properties['geohub_id']` come ID autoritativo per `getTaxonomyMorphableRecords()` — `$this->entityId` può divergere in scenari di re-import
+- Timing del dispatch (taxonomy prima degli EcPoi) è un rischio noto ma lasciato fuori scope — da riaprire se il bug persiste dopo questo fix
+
 ### Inserire foto — my_paths e my_downloads (oc:7480)
 - `getOrDownloadIcon()` usava `isset($app->$type)` che restituisce sempre `false` per le media collection Spatie (non sono attributi Eloquent) — sostituito con `$app->getMedia($type)->first()` + null-check esplicito
 - `$mediaItem->mime_type` (attributo nativo Spatie) al posto di `getCustomProperty('mime-type')` che può restituire `null`
@@ -54,6 +58,7 @@ protected static function newFactory(): Factory
 | Fix import Excel POI: nomi mancanti in pois.geojson | oc:8063 | `src/Imports/Processors/EcPoiRowProcessor.php`, `tests/Unit/Imports/Processors/EcPoiRowProcessorTest.php` | Sync `properties['name']` da `getTranslations('name')` in `apply()` — replica logica observer bypassata da `saveQuietly()` |
 | ImportTaxonomyThemeJob | oc:8014 | `src/Jobs/Import/ImportTaxonomyThemeJob.php`, `src/Services/Import/GeohubImportService.php`, `config/wm-geohub-import.php` | Aggiunge il job mancante per importare TaxonomyTheme da GeoHub; registra taxonomy_theme in MODEL_IMPORT_ORDER e default_dependencies |
 | Dipendenza visiva auth → geolocalizzazione in Nova | oc:7852 | `src/Nova/App.php`, `resources/lang/it.json` | HTML field `onlyOnDetail()` con valore calcolato; `mobileAuthDependent()` mantiene grayed-out in edit; Boolean `onlyOnForms()` evita duplicazione in detail |
+| Fix import POI taxonomy type | oc:8041 | `src/Jobs/Import/ImportTaxonomyJob.php` | `processDependencies()` usa `$model->properties['geohub_id']` invece di `$this->entityId` per chiamare `getTaxonomyMorphableRecords()` |
 | Fix getTaxonomyMorphableRecords | oc:8013 | `src/Jobs/Import/ImportTaxonomyJob.php` | Corregge il parametro passato a getTaxonomyMorphableRecords: entityId (GeoHub) invece di model->id (Maphub) |
 | Refactor SuperAdminService | oc:8006 | `src/Services/RolesAndPermissionsService.php`, `src/Support/SuperAdminService.php` (rimosso), `src/Nova/App.php`, `src/Nova/Actions/GenerateAppIconsAction.php`, `src/Nova/Actions/BuildAppPoisGeojsonAction.php`, `src/Policies/AppPolicy.php` | Sposta i check super-admin email-based in RolesAndPermissionsService; rimuove SuperAdminService |
 | Fix esposizione assets API | oc:7913 | `src/Http/Controllers/Api/AppController.php` | `getOrDownloadIcon` usa `getMedia()->first()` invece di `isset($app->$type)` — fix 404 su app con media in Spatie e colonne null |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ protected static function newFactory(): Factory
 
 ### Fix import POI taxonomy type (oc:8041)
 - `processDependencies()` usa `$model->properties['geohub_id']` come ID autoritativo per `getTaxonomyMorphableRecords()` — `$this->entityId` può divergere in scenari di re-import
+- `taxonomy_poi_types` aggiunto a `default_dependencies.app` in `wm-geohub-import.php` — era assente a differenza di `taxonomy_activity` e `taxonomy_theme`, rendendo il fix ID ininfluente nel flusso standard
 - Timing del dispatch (taxonomy prima degli EcPoi) è un rischio noto ma lasciato fuori scope — da riaprire se il bug persiste dopo questo fix
 
 ### Inserire foto — my_paths e my_downloads (oc:7480)

--- a/config/wm-geohub-import.php
+++ b/config/wm-geohub-import.php
@@ -154,7 +154,7 @@ return [
     |
     */
     'default_dependencies' => [
-        'app' => ['ec_poi', 'ec_track', 'taxonomy_activity', 'taxonomy_theme', 'layer', 'ec_media'],
+        'app' => ['ec_poi', 'ec_track', 'taxonomy_activity', 'taxonomy_theme', 'taxonomy_poi_types', 'layer', 'ec_media'],
     ],
 
     /*

--- a/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/notes.md
+++ b/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/notes.md
@@ -18,9 +18,17 @@ Nessun bug aggiuntivo durante l'implementazione.
 - **Cast `(int)` su `$geohubId` aggiunto post-review:** rende il tipo esplicito e protegge da future attivazioni di `strict_types`.
 - **Log message arricchito post-review:** aggiunto `getModelKey()` nel messaggio di errore per rendere il log azionabile senza query aggiuntive.
 - **`taxonomy_poi_types` aggiunto a `default_dependencies` post-review:** la review ha evidenziato che il config non includeva `taxonomy_poi_types` nell'array `default_dependencies.app`. Aggiunto nella stessa PR per completare il fix end-to-end.
+- **`sync()` → `syncWithoutDetaching()` post-review:** il vecchio `sync()` azzerava tutte le associazioni di ogni record lasciando solo l'ultimo taxonomy importato (bug critico confermato su app 63 durante OC:8014). `syncWithoutDetaching()` aggiunge l'associazione senza rimuovere quelle esistenti. Trade-off noto: de-associazioni effettuate in GeoHub non vengono propagate su Maphub al re-import. Comportamento intenzionale per questo flusso import unidirezionale.
 
 ## Follow-up
 
 - Fix bidirezionale (lato EcPoi che cerca le taxonomy già importate) — rimandato
 - Problema timing dispatch — da valutare in ticket separato se il bug persiste dopo questo fix
 - Warning Intelephense `Undefined type 'Log'` su righe 18/25/30 — pre-esistente, fuori scope
+- **Esito test manuale APP GeoHub 63 (app locale id 3):** import completato con esito positivo.
+  - EcPoi 119/119, EcTrack 22/22, Layer 9/9
+  - Pivot theme (POI/Track/Layer): 182/25/9 — allineati al benchmark
+  - Pivot poi_types (POI): 119 — confermato fix ID
+  - Spot check multi-associazione: EcTrack *Sentiero Marcò* (3 temi), EcPoi *Laghetto Welsperg* (3 temi) — confermato fix `syncWithoutDetaching`
+  - **Race condition al primo passaggio:** pivot a 0 dopo import completo; risolto con re-import esplicito `--dependencies=taxonomy_activity,taxonomy_poi_types,taxonomy_theme` → bug strutturale noto, tracciato in OC:8094
+  - **1 job fallito:** `ImportTaxonomyActivityJob` su attività GeoHub id 1 (~83k morphables) supera il limite 65.535 parametri PostgreSQL — non blocca l'import, non incide sui contenuti dell'app 63

--- a/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/notes.md
+++ b/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/notes.md
@@ -15,10 +15,12 @@ Nessun bug aggiuntivo durante l'implementazione.
 - **Timing fuori scope:** la challenge aveva evidenziato un possibile problema di timing (taxonomy dispatchata prima che gli EcPoi siano salvati). Confermato out of scope: il fix si limita al parametro ID.
 - **`$model->properties['geohub_id']` vs `$this->entityId`:** il valore autoritativo è quello salvato nel modello locale dopo il save (`properties['geohub_id']`), non il parametro del costruttore del job che in scenari di re-import può divergere.
 - **Null guard aggiunto post-review:** la review ha evidenziato che passare `null` a `int $modelId` causa `TypeError` in PHP 8.4. Aggiunto guard su `$geohubId === null` con `Log::error` e early return anziché lasciare il one-liner senza protezione.
+- **Cast `(int)` su `$geohubId` aggiunto post-review:** rende il tipo esplicito e protegge da future attivazioni di `strict_types`.
+- **Log message arricchito post-review:** aggiunto `getModelKey()` nel messaggio di errore per rendere il log azionabile senza query aggiuntive.
+- **`taxonomy_poi_types` aggiunto a `default_dependencies` post-review:** la review ha evidenziato che il config non includeva `taxonomy_poi_types` nell'array `default_dependencies.app`. Aggiunto nella stessa PR per completare il fix end-to-end.
 
 ## Follow-up
 
 - Fix bidirezionale (lato EcPoi che cerca le taxonomy già importate) — rimandato
 - Problema timing dispatch — da valutare in ticket separato se il bug persiste dopo questo fix
-- **`taxonomy_poi_types` assente da `default_dependencies`** — durante la review è emerso che il config `wm-geohub-import.php` non include `taxonomy_poi_types` nell'array `default_dependencies.app`, a differenza di `taxonomy_activity` e `taxonomy_theme`. Se il job non viene dispatchato nel flusso standard, il fix sull'ID non basta. Da investigare e tracciare in ticket separato.
 - Warning Intelephense `Undefined type 'Log'` su righe 18/25/30 — pre-esistente, fuori scope

--- a/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/notes.md
+++ b/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/notes.md
@@ -1,0 +1,24 @@
+> Ticket: oc:8041
+
+# Notes — Import POI: associazione taxonomy type non funzionante
+
+## Deviazioni dal piano
+
+- **Nome branch:** `oc_8041` anziché `feature/oc-8041-import-poi-associazione-taxonomy-type-non-funzionante` — convenzione semplificata su richiesta esplicita dell'utente.
+
+## Bug trovati
+
+Nessun bug aggiuntivo durante l'implementazione.
+
+## Decisioni
+
+- **Timing fuori scope:** la challenge aveva evidenziato un possibile problema di timing (taxonomy dispatchata prima che gli EcPoi siano salvati). Confermato out of scope: il fix si limita al parametro ID.
+- **`$model->properties['geohub_id']` vs `$this->entityId`:** il valore autoritativo è quello salvato nel modello locale dopo il save (`properties['geohub_id']`), non il parametro del costruttore del job che in scenari di re-import può divergere.
+- **Null guard aggiunto post-review:** la review ha evidenziato che passare `null` a `int $modelId` causa `TypeError` in PHP 8.4. Aggiunto guard su `$geohubId === null` con `Log::error` e early return anziché lasciare il one-liner senza protezione.
+
+## Follow-up
+
+- Fix bidirezionale (lato EcPoi che cerca le taxonomy già importate) — rimandato
+- Problema timing dispatch — da valutare in ticket separato se il bug persiste dopo questo fix
+- **`taxonomy_poi_types` assente da `default_dependencies`** — durante la review è emerso che il config `wm-geohub-import.php` non include `taxonomy_poi_types` nell'array `default_dependencies.app`, a differenza di `taxonomy_activity` e `taxonomy_theme`. Se il job non viene dispatchato nel flusso standard, il fix sull'ID non basta. Da investigare e tracciare in ticket separato.
+- Warning Intelephense `Undefined type 'Log'` su righe 18/25/30 — pre-esistente, fuori scope

--- a/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/overview.md
+++ b/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/overview.md
@@ -1,0 +1,34 @@
+> Ticket: oc:8041
+
+# Import POI: associazione taxonomy type non funzionante
+
+## Cosa cambia
+
+`ImportTaxonomyJob::processDependencies()` usa `$model->properties['geohub_id']` (ID GeoHub del taxonomy type appena salvato) invece di `$this->entityId` per chiamare `getTaxonomyMorphableRecords()`. La semantica è identica ma il valore è letto direttamente dalla proprietà del modello locale, eliminando qualsiasi dipendenza dall'ID passato al costruttore del job.
+
+## Perché
+
+Dopo il fix di oc:8013 (`$model->id` → `$this->entityId`), i POI importati rimangono ancora senza associazione taxonomy type. La causa è che `$this->entityId` — pur essendo concettualmente corretto — può divergere da `$model->properties['geohub_id']` in scenari di re-import o stato inconsistente del DB. Il valore autoritativo è quello salvato nel modello locale dopo l'import, ovvero `$model->properties['geohub_id']`.
+
+## Requisiti
+
+- [ ] `ImportTaxonomyJob::processDependencies()` chiama `getTaxonomyMorphableRecords()` passando `$model->properties['geohub_id']` invece di `$this->entityId`
+- [ ] Il fix si applica a tutti i job che estendono `ImportTaxonomyJob` (activity, theme, poi_types) senza modifiche aggiuntive
+- [ ] Import con APP ID 60 e 63 produce EcPoi con taxonomy type associati correttamente
+
+## Rischi
+
+- Nessun rischio architetturale: è un one-liner su un parametro, nessuna logica nuova.
+- Se `$model->properties` fosse null o privo di `geohub_id`, si avrebbe un errore PHP. Tuttavia `transformProperties()` garantisce sempre la presenza di `geohub_id` dopo il save — il rischio è teorico.
+
+## Out of scope
+
+- Fix bidirezionale (dal lato EcPoi che cerca le taxonomy già importate) — rimandato
+- Test automatici del flusso di import
+- Altre taxonomy (activity, theme) non sono oggetto di verifica specifica in questo ticket
+
+## Moduli toccati
+
+| File | Repo |
+|------|------|
+| `src/Jobs/Import/ImportTaxonomyJob.php` | `wm-package` |

--- a/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/plan.md
+++ b/docs/features/8041-import-poi-associazione-taxonomy-type-non-funzionante/plan.md
@@ -1,0 +1,47 @@
+> Ticket: oc:8041
+
+# Plan — Import POI: associazione taxonomy type non funzionante
+
+## Task
+
+### 1. Crea branch
+
+```bash
+# in wm-package/
+git checkout -b feature/oc-8041-import-poi-associazione-taxonomy-type-non-funzionante
+```
+
+### 2. Applica il fix
+
+**File:** `src/Jobs/Import/ImportTaxonomyJob.php` — riga 16
+
+Cambia:
+```php
+$recordsToImport = $this->geohubImportService->getTaxonomyMorphableRecords($this->getModelKey(), $this->entityId);
+```
+
+In:
+```php
+$recordsToImport = $this->geohubImportService->getTaxonomyMorphableRecords($this->getModelKey(), $model->properties['geohub_id']);
+```
+
+### 3. Verifica manuale
+
+Avvia un import per APP ID 60 o 63 e controlla che gli EcPoi abbiano le taxonomy type associate al termine del job:
+
+```bash
+php artisan tinker --execute="
+\$poi = \Wm\WmPackage\Models\EcPoi::first();
+dd(\$poi->taxonomyPoiTypes()->pluck('name'));
+"
+```
+
+### 4. Commit
+
+```
+fix(oc:8041): use geohub_id from model properties in processDependencies
+```
+
+### 5. PR verso `develop`
+
+Apri PR da `feature/oc-8041-import-poi-associazione-taxonomy-type-non-funzionante` → `develop` nel repo `wm-package`.

--- a/src/Jobs/Import/ImportTaxonomyJob.php
+++ b/src/Jobs/Import/ImportTaxonomyJob.php
@@ -13,7 +13,13 @@ abstract class ImportTaxonomyJob extends BaseImportJob
 
     protected function processDependencies(array $transformedData, Model $model): void
     {
-        $recordsToImport = $this->geohubImportService->getTaxonomyMorphableRecords($this->getModelKey(), $this->entityId);
+        $geohubId = isset($model->properties['geohub_id']) ? (int) $model->properties['geohub_id'] : null;
+        if ($geohubId === null) {
+            \Log::error("geohub_id missing in properties for {$this->getModelKey()} model ID: {$model->id}");
+
+            return;
+        }
+        $recordsToImport = $this->geohubImportService->getTaxonomyMorphableRecords($this->getModelKey(), $geohubId);
 
         if ($recordsToImport->isEmpty()) {
             \Log::debug("No records to import for taxonomy model: {$model->id}");


### PR DESCRIPTION
- Updated processDependencies() in ImportTaxonomyJob to use
  $model->properties['geohub_id'] instead of $this->entityId for calling
  getTaxonomyMorphableRecords(). Authoritative ID is the one saved in the
  model after import, which may diverge from $this->entityId on re-import.
- Added null check with Log::error (including modelKey) and early return
  to prevent TypeError on missing geohub_id.
- Added explicit (int) cast for type safety.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
