### PR TITLE
feat(oc:8139): auto-associate EcPoi to layer via track relation

### DIFF
--- a/docs/features/8139-associazione-automatica-ecpoi-al-layer-della-traccia/overview.md
+++ b/docs/features/8139-associazione-automatica-ecpoi-al-layer-della-traccia/overview.md
@@ -1,0 +1,14 @@
+> Ticket: oc:8139
+
+# Associazione automatica EcPoi al layer della traccia — wm-package
+
+## Cosa cambia
+
+`EcPoiEcTrackObserver` intercetta aggiunta/rimozione di un `EcPoi` da una `EcTrack` e sincronizza la relazione `ecPois` del layer. La relazione `manualEcPois` viene rinominata `ecPois` con alias per backwards compatibility.
+
+## Moduli toccati
+
+- `src/Observers/EcPoiEcTrackObserver.php`
+- `src/Models/Layer.php`
+- `src/Models/EcPoi.php`
+- `src/Nova/Layer.php`

--- a/src/Models/EcPoi.php
+++ b/src/Models/EcPoi.php
@@ -286,7 +286,7 @@ class EcPoi extends Point implements LayerRelatedModel
 
     public function getLayerRelationName(): string
     {
-        return 'manualEcPois';
+        return 'ecPois';
     }
 
     private function getValuesOfMorphToMany($relation, $slug): array

--- a/src/Models/EcPoi.php
+++ b/src/Models/EcPoi.php
@@ -286,7 +286,7 @@ class EcPoi extends Point implements LayerRelatedModel
 
     public function getLayerRelationName(): string
     {
-        return 'ecPois';
+        return 'manualEcPois';
     }
 
     private function getValuesOfMorphToMany($relation, $slug): array

--- a/src/Models/EcPoiEcTrack.php
+++ b/src/Models/EcPoiEcTrack.php
@@ -4,6 +4,8 @@ namespace Wm\WmPackage\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\DB;
 use Wm\WmPackage\Observers\EcPoiEcTrackObserver;
 
 class EcPoiEcTrack extends Pivot
@@ -51,5 +53,28 @@ class EcPoiEcTrack extends Pivot
         $tableName = config('wm-package.ec_track_table', 'ec_tracks');
 
         return rtrim($tableName, 's').'_id';
+    }
+
+    /**
+     * Check whether a POI is still linked to a layer via at least one other track
+     * (excluding $excludeTrackId). Used by observers to decide whether to detach a POI
+     * when a track-POI or track-layer association is removed.
+     */
+    public static function poiStillLinkedToLayerViaOtherTrack(int $layerId, int $ecPoiId, int $excludeTrackId): bool
+    {
+        $fkName = self::getTrackForeignKeyName();
+        $pivotTable = config('wm-package.ec_poi_track_pivot_table', 'ec_poi_ec_track');
+        $ecTrackModelClass = config('wm-package.ec_track_model', EcTrack::class);
+        $ecTrackMorphType = array_search($ecTrackModelClass, Relation::morphMap()) ?: $ecTrackModelClass;
+
+        return DB::table($pivotTable)
+            ->join('layerables', function ($join) use ($layerId, $fkName, $ecTrackMorphType, $pivotTable) {
+                $join->on('layerables.layerable_id', '=', "{$pivotTable}.{$fkName}")
+                    ->where('layerables.layerable_type', $ecTrackMorphType)
+                    ->where('layerables.layer_id', $layerId);
+            })
+            ->where("{$pivotTable}.ec_poi_id", $ecPoiId)
+            ->where("{$pivotTable}.{$fkName}", '!=', $excludeTrackId)
+            ->exists();
     }
 }

--- a/src/Models/Layer.php
+++ b/src/Models/Layer.php
@@ -111,9 +111,15 @@ class Layer extends Polygon
         return $this->morphedByMany($ecTrackModelClass, 'layerable')->using(Layerable::class);
     }
 
-    public function manualEcPois(): MorphToMany
+    public function ecPois(): MorphToMany
     {
         return $this->morphedByMany(EcPoi::class, 'layerable')->using(Layerable::class);
+    }
+
+    /** @deprecated use ecPois() */
+    public function manualEcPois(): MorphToMany
+    {
+        return $this->ecPois();
     }
 
     public function taxonomyActivities(): MorphToMany

--- a/src/Models/Layer.php
+++ b/src/Models/Layer.php
@@ -111,15 +111,9 @@ class Layer extends Polygon
         return $this->morphedByMany($ecTrackModelClass, 'layerable')->using(Layerable::class);
     }
 
-    public function ecPois(): MorphToMany
-    {
-        return $this->morphedByMany(EcPoi::class, 'layerable')->using(Layerable::class);
-    }
-
-    /** @deprecated use ecPois() */
     public function manualEcPois(): MorphToMany
     {
-        return $this->ecPois();
+        return $this->morphedByMany(EcPoi::class, 'layerable')->using(Layerable::class);
     }
 
     public function taxonomyActivities(): MorphToMany

--- a/src/Nova/Layer.php
+++ b/src/Nova/Layer.php
@@ -33,7 +33,7 @@ class Layer extends AbstractGeometryResource
         fields as protected fieldsTrait;
     }
 
-    public static $with = ['ecTracks', 'manualEcPois', 'appOwner', 'associatedApps'];
+    public static $with = ['ecTracks', 'ecPois', 'appOwner', 'associatedApps'];
 
     public static $model = LayerModel::class;
 
@@ -98,6 +98,11 @@ class Layer extends AbstractGeometryResource
                 LayerFeatures::make(__('tracks'), $this->resource, config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack'))
                     ->hideWhenCreating()
                     ->withMeta(['model_class' => config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack')]),
+            ]),
+            Panel::make('Ec Pois', [
+                LayerFeatures::make(__('pois'), $this->resource, config('wm-package.ec_poi_model', 'Wm\WmPackage\Models\EcPoi'))
+                    ->hideWhenCreating()
+                    ->withMeta(['model_class' => config('wm-package.ec_poi_model', 'Wm\WmPackage\Models\EcPoi')]),
             ]),
             Text::make(__('Web Component'), function () {
                 /** @var LayerModel $layer */

--- a/src/Nova/Layer.php
+++ b/src/Nova/Layer.php
@@ -33,7 +33,7 @@ class Layer extends AbstractGeometryResource
         fields as protected fieldsTrait;
     }
 
-    public static $with = ['ecTracks', 'ecPois', 'appOwner', 'associatedApps'];
+    public static $with = ['ecTracks', 'manualEcPois', 'appOwner', 'associatedApps'];
 
     public static $model = LayerModel::class;
 
@@ -98,11 +98,6 @@ class Layer extends AbstractGeometryResource
                 LayerFeatures::make(__('tracks'), $this->resource, config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack'))
                     ->hideWhenCreating()
                     ->withMeta(['model_class' => config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack')]),
-            ]),
-            Panel::make('Ec Pois', [
-                LayerFeatures::make(__('pois'), $this->resource, config('wm-package.ec_poi_model', 'Wm\WmPackage\Models\EcPoi'))
-                    ->hideWhenCreating()
-                    ->withMeta(['model_class' => config('wm-package.ec_poi_model', 'Wm\WmPackage\Models\EcPoi')]),
             ]),
             Text::make(__('Web Component'), function () {
                 /** @var LayerModel $layer */

--- a/src/Observers/EcPoiEcTrackObserver.php
+++ b/src/Observers/EcPoiEcTrackObserver.php
@@ -2,8 +2,6 @@
 
 namespace Wm\WmPackage\Observers;
 
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Facades\DB;
 use Wm\WmPackage\Models\EcPoiEcTrack;
 use Wm\WmPackage\Models\EcTrack;
 use Wm\WmPackage\Services\Models\EcTrackService;
@@ -66,28 +64,11 @@ class EcPoiEcTrackObserver
             if ($action === 'attach') {
                 $layer->ecPois()->syncWithoutDetaching([$ecPoiId]);
             } else {
-                if (! $this->layerStillHasPoiViaOtherTrack($layer->id, $ecPoiId, $ecTrackId, $fkName)) {
+                if (! EcPoiEcTrack::poiStillLinkedToLayerViaOtherTrack($layer->id, $ecPoiId, $ecTrackId)) {
                     $layer->ecPois()->detach($ecPoiId);
                 }
             }
         }
-    }
-
-    private function layerStillHasPoiViaOtherTrack(int $layerId, int $ecPoiId, int $excludeTrackId, string $fkName): bool
-    {
-        $pivotTable = config('wm-package.ec_poi_track_pivot_table', 'ec_poi_ec_track');
-        $ecTrackModelClass = config('wm-package.ec_track_model', EcTrack::class);
-        $ecTrackMorphType = array_search($ecTrackModelClass, Relation::morphMap()) ?: $ecTrackModelClass;
-
-        return DB::table($pivotTable)
-            ->join('layerables', function ($join) use ($layerId, $fkName, $ecTrackMorphType, $pivotTable) {
-                $join->on('layerables.layerable_id', '=', "{$pivotTable}.{$fkName}")
-                    ->where('layerables.layerable_type', $ecTrackMorphType)
-                    ->where('layerables.layer_id', $layerId);
-            })
-            ->where("{$pivotTable}.ec_poi_id", $ecPoiId)
-            ->where("{$pivotTable}.{$fkName}", '!=', $excludeTrackId)
-            ->exists();
     }
 
     private function updateEcTrackDataChain(EcPoiEcTrack $pivot): void

--- a/src/Observers/EcPoiEcTrackObserver.php
+++ b/src/Observers/EcPoiEcTrackObserver.php
@@ -2,53 +2,95 @@
 
 namespace Wm\WmPackage\Observers;
 
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\DB;
 use Wm\WmPackage\Models\EcPoiEcTrack;
 use Wm\WmPackage\Models\EcTrack;
 use Wm\WmPackage\Services\Models\EcTrackService;
 
 class EcPoiEcTrackObserver
 {
-    /**
-     * Handle the EcPoiEcTrack "created" event.
-     * Triggered when a POI is attached to a track.
-     *
-     * @return void
-     */
-    public function created(EcPoiEcTrack $pivot)
+    public function created(EcPoiEcTrack $pivot): void
+    {
+        $this->updateEcTrackDataChain($pivot);
+        $this->syncPoiToLayers($pivot, 'attach');
+    }
+
+    public function updated(EcPoiEcTrack $pivot): void
     {
         $this->updateEcTrackDataChain($pivot);
     }
 
-    /**
-     * Handle the EcPoiEcTrack "updated" event.
-     * Triggered when a pivot record is updated (e.g., order changed).
-     *
-     * @return void
-     */
-    public function updated(EcPoiEcTrack $pivot)
+    public function deleted(EcPoiEcTrack $pivot): void
     {
         $this->updateEcTrackDataChain($pivot);
+        $this->syncPoiToLayers($pivot, 'detach');
     }
 
     /**
-     * Handle the EcPoiEcTrack "deleted" event.
-     * Triggered when a POI is detached from a track.
+     * Sync the EcPoi with the layers of its EcTrack.
+     * On attach: associate the POI with all layers of the track.
+     * On detach: dissociate the POI from a layer only if no other track
+     *            in that layer still has the POI as a related poi.
      *
-     * @return void
+     * NOTE: This observer fires in wm-package but relies on LayerableObserver
+     * (registered in the consumer project) to handle ownership transfer on
+     * the created layerable. This cross-layer dependency is intentional —
+     * same pattern as oc:8080. If LayerableObserver is absent, ownership
+     * transfer will not occur, but the association itself will.
      */
-    public function deleted(EcPoiEcTrack $pivot)
+    private function syncPoiToLayers(EcPoiEcTrack $pivot, string $action): void
     {
-        $this->updateEcTrackDataChain($pivot);
+        $fkName = EcPoiEcTrack::getTrackForeignKeyName();
+        $ecTrackId = $pivot->getAttribute($fkName);
+        $ecPoiId = $pivot->getAttribute('ec_poi_id');
+
+        if (! $ecTrackId || ! $ecPoiId) {
+            return;
+        }
+
+        $ecTrackModelClass = config('wm-package.ec_track_model', EcTrack::class);
+        $ecTrack = $ecTrackModelClass::find($ecTrackId);
+
+        if (! $ecTrack || ! method_exists($ecTrack, 'associatedLayers')) {
+            return;
+        }
+
+        $layers = $ecTrack->associatedLayers;
+
+        if ($layers->isEmpty()) {
+            return;
+        }
+
+        foreach ($layers as $layer) {
+            if ($action === 'attach') {
+                $layer->ecPois()->syncWithoutDetaching([$ecPoiId]);
+            } else {
+                if (! $this->layerStillHasPoiViaOtherTrack($layer->id, $ecPoiId, $ecTrackId, $fkName)) {
+                    $layer->ecPois()->detach($ecPoiId);
+                }
+            }
+        }
     }
 
-    /**
-     * Update the EcTrack data chain when POI relationships change.
-     * Uses config('wm-package.ec_track_model') to resolve the correct model class,
-     * and EcPoiEcTrack::getTrackForeignKeyName() to resolve the correct FK,
-     *
-     * @return void
-     */
-    private function updateEcTrackDataChain(EcPoiEcTrack $pivot)
+    private function layerStillHasPoiViaOtherTrack(int $layerId, int $ecPoiId, int $excludeTrackId, string $fkName): bool
+    {
+        $pivotTable = config('wm-package.ec_poi_track_pivot_table', 'ec_poi_ec_track');
+        $ecTrackModelClass = config('wm-package.ec_track_model', EcTrack::class);
+        $ecTrackMorphType = array_search($ecTrackModelClass, Relation::morphMap()) ?: $ecTrackModelClass;
+
+        return DB::table($pivotTable)
+            ->join('layerables', function ($join) use ($layerId, $fkName, $ecTrackMorphType, $pivotTable) {
+                $join->on('layerables.layerable_id', '=', "{$pivotTable}.{$fkName}")
+                    ->where('layerables.layerable_type', $ecTrackMorphType)
+                    ->where('layerables.layer_id', $layerId);
+            })
+            ->where("{$pivotTable}.ec_poi_id", $ecPoiId)
+            ->where("{$pivotTable}.{$fkName}", '!=', $excludeTrackId)
+            ->exists();
+    }
+
+    private function updateEcTrackDataChain(EcPoiEcTrack $pivot): void
     {
         $ecTrackModelClass = config('wm-package.ec_track_model', EcTrack::class);
         $fkName = EcPoiEcTrack::getTrackForeignKeyName();


### PR DESCRIPTION
## Summary

- `EcPoiEcTrackObserver`: sincronizza automaticamente un EcPoi ai layer della traccia quando viene aggiunto/rimosso dal pivot `ec_poi_ec_track`
- `Layer::ecPois()`: rinominato da `manualEcPois()`, alias `@deprecated` mantenuto per BC
- `EcPoi::getLayerRelationName()`: restituisce `'ecPois'` per compatibilità con `LayerFeatures` Nova field
- `Nova/Layer`: `$with` aggiornato a `ecPois`
- `EcPoiEcTrack::poiStillLinkedToLayerViaOtherTrack()`: metodo statico centralizzato per la query "POI ancora linkato al layer via altra traccia" — elimina duplicazione con il repo consumer

## Test plan

- [ ] `LayerEcPoiSyncObserverTest`: 4 test — attach/detach POI da traccia, POI condiviso tra tracce, POI condiviso tra layer
- [ ] Suite completa senza regressioni

🤖 Generated with [Claude Code](https://claude.com/claude-code)