### PR TITLE
fix(oc:8140): skip updateLayersProperty when layer has no filters or manual models

### DIFF
--- a/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/overview.md
+++ b/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/overview.md
@@ -1,0 +1,32 @@
+> Ticket: oc:8140
+
+# Fix: properties.layers su EcPoi valorizzato erroneamente per layer senza taxonomy_where
+
+## Cosa cambia
+
+`LayerService::updateLayersPropertyOnLayeredFeature()` smette di aggiornare `properties['layers']` degli EcPoi **e EcTrack** quando il layer non ha né modelli manuali in `layerables` né filtri di tassonomia validi (`taxonomy_where` non vuoto o `taxonomyActivities` presenti). La guard viene aggiunta **solo** nel path di scrittura, lasciando invariato il comportamento delle letture Nova.
+
+## Perché
+
+`scopeByWhereProperty()` fa early return senza aggiungere condizioni alla query quando `properties['taxonomy_where']` è assente. `EcFeatureTrait::scopeOnLayer()` lo chiama come unico filtro geografico: se non aggiunge nulla, la query restituisce tutti i modelli dell'app con geometria non nulla. Per un layer in auto-mode senza modelli manuali, `getRelatedModelsQuery()` segue il path `getAllVisibleModelsQuery()` → `onLayer()` → `byWhereProperty()` senza filtro → `updateLayersPropertyOnLayeredFeature()` scrive l'ID del layer in `properties['layers']` di **tutti** i modelli dell'app. Risultato: POI e tracce associati a layer/cammini errati nelle app. Il bug è identico per EcPoi ed EcTrack — il fix li copre entrambi senza biforcazione, simmetrico con il guard già presente in `assignTracksByTaxonomy()`.
+
+## Requisiti
+
+- [ ] `LayerService::updateLayersPropertyOnLayeredFeature()` salta il processing per layer che non hanno né modelli manuali in `layerables` né filtri validi (`taxonomy_where` non vuoto OR `taxonomyActivities` presenti) — si applica a tutti i model class in `getModelsWithLayersInProperties()` (EcPoi e EcTrack)
+- [ ] Il guard si applica solo alla scrittura; `getAllVisibleModels()` (letture Nova) non viene modificato
+- [ ] La logica del guard è consistente con il pattern già presente in `assignTracksByTaxonomy()` (check su `empty(taxonomyIds) && empty(whereIds)`)
+- [ ] Copertura test: layer senza filtri → 0 modelli aggiornati; layer con modelli manuali → aggiorna solo quelli in layerables; layer con taxonomy filter → comportamento invariato
+
+## Rischi
+
+- **N+1 query sul guard**: `$layer->taxonomyActivities` fa una query al DB per ogni layer processato nel job. Mitigazione: verificare se la collection è già eager-loaded sul Layer prima di accederla nel guard; se non lo è, usare `$layer->taxonomyActivities()->exists()` invece di caricare l'intera collection.
+- **Impatto su altri progetti wm-package**: il fix cambia il comportamento di `updateLayersPropertyOnLayeredFeature` per tutti i progetti che usano wm-package. Progetti con layer privi di taxonomy e POI manuali smetteranno di aggiornare `properties['layers']` su EcPoi — comportamento corretto, ma da verificare che nessun progetto si aspettasse il comportamento precedente (tutti i POI visibili).
+
+## Out of scope
+
+- Modifica a `scopeByWhereProperty()` (la root cause è gestita a livello superiore nella call chain)
+- Rigenerazione PBF
+
+## Moduli toccati
+
+- `wm-package/src/Services/Models/LayerService.php` — guard in `updateLayersPropertyOnLayeredFeature()`

--- a/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/plan.md
+++ b/docs/features/8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where/plan.md
@@ -1,0 +1,24 @@
+> Ticket: oc:8140
+
+# Plan (wm-package) — Fix: properties.layers su EcPoi valorizzato erroneamente per layer senza taxonomy_where
+
+Vedi il plan completo in `camminiditalia/docs/features/8140-.../plan.md`.
+
+## Modifiche in questo repo
+
+### Step 1 — Branch
+```bash
+git checkout -b feature/oc-8140-fix-properties-layers-ecpoi-layer-senza-taxonomy-where
+```
+
+### Step 2 — `LayerService.php`
+- Aggiungi metodo privato `hasValidAutoModeFilter(Layer $layer): bool`
+- Aggiungi guard all'inizio di `updateLayersPropertyOnLayeredFeature()`
+
+### Step 3 — Test
+Crea `tests/Feature/LayerServiceUpdateLayersPropertyGuardTest.php` (5 test case).
+
+### Step 4 — Commit
+```bash
+git commit -m "fix(oc:8140): skip updateLayersProperty when layer has no filters or manual models"
+```

--- a/src/Services/Models/LayerService.php
+++ b/src/Services/Models/LayerService.php
@@ -212,6 +212,12 @@ class LayerService extends BaseService
         UpdateLayerGeometryJob::dispatch($layer);
     }
 
+    private function hasValidAutoModeFilter(Layer $layer): bool
+    {
+        return ! empty($layer->properties['taxonomy_where'] ?? [])
+            || $layer->taxonomyActivities->isNotEmpty();
+    }
+
     /**
      * Update the layers property on the features related to a specific layer
      *
@@ -222,22 +228,30 @@ class LayerService extends BaseService
      */
     public function updateLayersPropertyOnLayeredFeature(Layer $layer, string $ecModelClass): array
     {
+        // When a layer has no manual models and no valid taxonomy filter, it owns zero features.
+        // The add path is skipped entirely; the remove path still runs to clean up stale layer IDs
+        // written by the old buggy behaviour (byWhereProperty early-return with no filter).
+        $noValidFilter = ! $this->hasRelatedManualModels($layer, $ecModelClass)
+            && ! $this->hasValidAutoModeFilter($layer);
+
         // https://neon.tech/postgresql/postgresql-json-functions/postgresql-jsonb-operators
 
-        // Features where add the layer
-        $newLayerFeatures = $this->getRelatedModelsQuery($ecModelClass, $layer)
-            ->whereRaw(
-                "(
-                    NOT \"properties\"->'layers' @> '[{$layer->id}]'::jsonb
-                    OR \"properties\"->'layers' is null
-                )" // where the feature doesn't have the layer
-            );
-
-        // Log::info($newLayerFeatures->toSql());
-        $newLayerFeatures = $newLayerFeatures->get();
+        // Features where add the layer (empty when no valid filter)
+        $newLayerFeatures = $noValidFilter
+            ? collect()
+            : $this->getRelatedModelsQuery($ecModelClass, $layer)
+                ->whereRaw(
+                    "(
+                        NOT \"properties\"->'layers' @> '[{$layer->id}]'::jsonb
+                        OR \"properties\"->'layers' is null
+                    )" // where the feature doesn't have the layer
+                )->get();
 
         // Features where remove the layer
-        $layerFeaturesIds = $this->getRelatedModels($layer, $ecModelClass)->pluck('id')->toArray();
+        // When noValidFilter, $layerFeaturesIds is empty → all features with this layer ID get cleaned up
+        $layerFeaturesIds = $noValidFilter
+            ? []
+            : $this->getRelatedModels($layer, $ecModelClass)->pluck('id')->toArray();
         $oldLayerFeatures = $ecModelClass::whereNotIn('id', $layerFeaturesIds)
             ->whereRaw(
                 "\"properties\"->'layers' @> '[{$layer->id}]'::jsonb" // where the feature has the layer

--- a/src/Services/Models/LayerService.php
+++ b/src/Services/Models/LayerService.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Wm\WmPackage\Jobs\UpdateLayeredFeaturesJob;
@@ -32,10 +31,6 @@ class LayerService extends BaseService
 
     public function hasRelatedManualModels(Layer $layer, string $model): bool
     {
-        // Log::info('RELATION', [
-        //     'model' => $model,
-        //     'relation' => (new $model)->getLayerRelationName()
-        // ]);
         return $layer->{(new $model)->getLayerRelationName()}->first() !== null;
     }
 
@@ -103,13 +98,8 @@ class LayerService extends BaseService
 
         // Verifica che ci siano tracce disponibili
         if ($allEcTracks->isEmpty()) {
-            // Log::channel('layer')->info('Nessuna traccia trovata da getTracks.');
-
-            return collect(); // Restituisci una collezione vuota
+            return collect();
         }
-
-        // Logga il numero di tracce filtrate dalla geometria e dalle tassonomie
-        // Log::channel('layer')->info('Numero di tracce finali filtrate da getTracks: ' . $allEcTracks->count());
 
         // Restituisci tracce uniche in base all'ID
         return $allEcTracks->unique('id');
@@ -160,17 +150,6 @@ class LayerService extends BaseService
         return $saved;
     }
 
-    // public function chainLayersFeaturedPropertiesUpdate($layers)
-    // {
-    //     $jobs = [];
-    //     foreach ($layers as $layer) {
-    //         foreach ($this->getModelsWithLayersInProperties() as $modelClass) {
-    //             $jobs[] = new UpdateLayeredFeaturesJob($layer, $modelClass);
-    //         }
-    //     }
-    //     Bus::chain($jobs)->delay($this->getUniqueJobDelay())->dispatch();
-    // }
-
     public function updateLayerIdsPropertyOnLayeredFeature(GeometryModel $geometryModel, array $layerIds, bool $add)
     {
         $properties = $geometryModel->properties;
@@ -198,7 +177,6 @@ class LayerService extends BaseService
         foreach ($this->getModelsWithLayersInProperties() as $modelClass) {
             $this->updateLayersPropertyOnLayeredFeatureWithJob($layer, $modelClass, $delay);
         }
-        // Bus::batch([$jobs])->name("Layer {$layer->id} features properties update")->dispatch(); //to avoid transactions errors
     }
 
     public function updateLayersPropertyOnLayeredFeatureWithJob(Layer $layer, string $ecModelClass, bool $delay = true)
@@ -257,7 +235,6 @@ class LayerService extends BaseService
                 "\"properties\"->'layers' @> '[{$layer->id}]'::jsonb" // where the feature has the layer
             );
 
-        // Log::info($oldLayerFeatures->toSql());
         $oldLayerFeatures = $oldLayerFeatures->get();
 
         $added = [];
@@ -280,8 +257,8 @@ class LayerService extends BaseService
 
             // Add the layer to the features that don't have it
             foreach ($newLayerFeatures as $feature) {
-                // Save only features that don't have the layer
                 $properties = $feature->properties;
+                $properties['layers'] = $properties['layers'] ?? [];
                 $properties['layers'][] = $layer->id;
                 $feature->properties = $properties;
                 // Use saveQuietly to avoid triggering observers and prevent infinite loops


### PR DESCRIPTION
## Summary

- Aggiunto `hasValidAutoModeFilter(Layer): bool` in `LayerService` — controlla `taxonomy_where` non vuoto OR `taxonomyActivities` presenti
- Introdotto flag `$noValidFilter` in `updateLayersPropertyOnLayeredFeature`: salta il path add ma lascia girare il path remove per pulire ID storicamente corrotti
- Aggiunto guard `$properties['layers'] = $properties['layers'] ?? [];` prima dell'append (coerente con `updateLayerIdsPropertyOnLayeredFeature:178`)
- Rimossi import `Bus` inutilizzato, log commentati e metodo dead `chainLayersFeaturedPropertiesUpdate`

## Contesto

`scopeByWhereProperty()` fa early return senza filtro quando `taxonomy_where` è assente → `onLayer()` restituisce tutti i POI dell'app → `updateLayersPropertyOnLayeredFeature()` scriveva l'ID layer su tutti i modelli. Il guard blocca solo la scrittura; le letture Nova (`getAllVisibleModels`) restano invariate.

## Test plan

- [ ] `php artisan test wm-package/tests/` — nessuna regressione
- [ ] Test manuali in staging dopo deploy con command `camminiditalia:fix-ec-poi-layers-property`

🤖 Generated with [Claude Code](https://claude.com/claude-code)