### PR TITLE
feat(oc:8160): move Geometry to dedicated Map panel and show EcPoi on layer map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,11 @@ protected static function newFactory(): Factory
 
 ## Decisioni architetturali
 
+### Layer Nova: Map panel e EcPoi sulla mappa (oc:8160)
+- `addFeaturesForMap()` in `FeatureCollectionMapTrait` inietta `$this->id` (= ID del layer) in ogni feature — non causa problemi perché il click usa la property `link` (URL completo), non `id`. L'`id` è rilevante solo in modalità popup, non usata per EcTrack/EcPoi sulla mappa del layer
+- Tabella `ec_pois` hardcoded nella raw SQL di `getFeatureCollectionMap()` — stessa scelta di `taxonomy_wheres` nello stesso metodo; nessun `ec_poi_table` in config per simmetria con `ec_track_table`
+- I test per `getFeatureCollectionMap()` sono in `wm-package/tests/Feature/` con `Wm\WmPackage\Tests\TestCase` — girano dalla suite phpunit del package (DB `wm_package`), non da `php artisan test` di camminiditalia
+
 ### Fix import POI taxonomy type (oc:8041)
 - `processDependencies()` usa `$model->properties['geohub_id']` come ID autoritativo per `getTaxonomyMorphableRecords()` — `$this->entityId` può divergere in scenari di re-import
 - `taxonomy_poi_types` aggiunto a `default_dependencies.app` in `wm-geohub-import.php` — era assente a differenza di `taxonomy_activity` e `taxonomy_theme`, rendendo il fix ID ininfluente nel flusso standard
@@ -53,6 +58,7 @@ protected static function newFactory(): Factory
 | Feature | Ticket | Moduli toccati | Note |
 |---|---|---|---|
 | Utenti importati: ruolo Editor in import GeoHub | oc:8042 | `src/Services/Import/GeohubImportService.php`, `src/Services/RolesAndPermissionsService.php`, `database/migrations/zz_2026_06_26_000001_add_editor_role.php.stub` | `assignEditorRole()` condizionale; Editor aggiunto a `seedDatabase()` |
+| Layer Nova: Map panel dedicato + EcPoi sulla mappa | oc:8160 | `src/Nova/Layer.php`, `src/Models/Layer.php`, `resources/lang/it.json`, `resources/lang/en.json` | `FeatureCollectionMap` spostato in panel `__('Map')` separato; `getFeatureCollectionMap()` include EcPoi come Point features (tooltip nome, link `ec-pois/{id}`) |
 | BulkEditAction: bulk edit dinamico da Nova Resource | oc:8133 | `src/Nova/Actions/BulkEditAction.php`, `tests/Unit/Nova/Actions/BulkEditActionTest.php`, `tests/Feature/Nova/Actions/BulkEditActionFeatureTest.php` | Action parametrica: `new BulkEditAction(Resource::class, ['field'])` — filtra campi da Resource, appiattisce Panel/Tab, `saveQuietly()` in `DB::transaction()` |
 | Analytics Layer: selezione range temporale | oc:7648 | `src/Services/PostHog/AnalyticsService.php`, `src/Http/Controllers/Nova/AnalyticsController.php`, `src/Nova/Cards/LayerAnalytics/` | Dropdown 30/90/365gg + mesi da created_at; tabella download per traccia |
 | Inserire foto (my_paths, my_downloads) | oc:7480 | `src/Models/App.php`, `src/Nova/App.php`, `src/Http/Controllers/Api/AppController.php`, `routes/api.php`, `src/Services/Models/App/AppConfigService.php` | Media collection + Nova fields + route nei 3 gruppi + URL in APP section del config.json; fix getOrDownloadIcon() (isset→getMedia, mime_type, driver null-safe) |

--- a/docs/features/8160-layer-nova-map-panel-ec-poi/notes.md
+++ b/docs/features/8160-layer-nova-map-panel-ec-poi/notes.md
@@ -1,0 +1,23 @@
+> Ticket: oc:8160
+
+# Notes — Layer Nova: sposta Geometry fuori dal panel Ec Tracks e mostra anche EcPoi sulla mappa
+
+## Deviazioni dal piano
+
+Nessuna deviazione rilevante. Tutti gli step del piano sono stati eseguiti come pianificato.
+
+## Bug trovati
+
+Nessuno.
+
+## Decisioni
+
+- **Pattern EcPoi identico a EcTrack** — Il revisore adversariale aveva segnalato come criticità l'`id` del layer iniettato su ogni feature da `addFeaturesForMap()`. Verificando il codice EcTrack esistente, si è confermato che lo stesso comportamento è già presente per le tracce senza causare problemi: il click usa la property `link` (URL completo), non `id`. L'`id` viene usato solo in modalità popup, non in uso qui. Nessuna modifica al trait necessaria.
+
+- **Test in wm-package con `Wm\WmPackage\Tests\TestCase`** — I test sono in `wm-package/tests/Feature/` e usano il TestCase del package, coerentemente con tutti gli altri test esistenti in quella directory. Non girano via `php artisan test` di camminiditalia (richiedono il DB separato `wm_package` e la suite phpunit propria del package).
+
+- **Tabella `ec_pois` hardcoded** — Nessun `ec_poi_table` in config (a differenza di `ec_track_table`). Usato lo stesso approccio di `taxonomy_wheres` nello stesso metodo: nome tabella hardcoded. Rischio accettato per coerenza con il pattern esistente.
+
+## Follow-up
+
+- Valutare se aggiungere `ec_poi_table` alla configurazione del package per simmetria con `ec_track_table` — bassa priorità, nessun caso d'uso noto che richieda un nome tabella custom per EcPoi.

--- a/docs/features/8160-layer-nova-map-panel-ec-poi/overview.md
+++ b/docs/features/8160-layer-nova-map-panel-ec-poi/overview.md
@@ -1,0 +1,48 @@
+> Ticket: oc:8160
+
+# Layer Nova: sposta Geometry fuori dal panel Ec Tracks e mostra anche EcPoi sulla mappa
+
+## Cosa cambia
+
+Nella pagina di dettaglio del Layer in Nova:
+
+1. `FeatureCollectionMap` viene spostato fuori dal `Panel::make('Ec Tracks', [...])` in un panel dedicato `Panel::make(__('Map'), [...])`, posizionato prima dei panel "Ec Tracks" ed "Ec Pois".
+2. `Layer::getFeatureCollectionMap()` viene esteso per includere le geometrie degli EcPoi associati al layer (via tabella `layerables`), con tooltip sul nome e link alla scheda Nova del POI.
+3. Aggiunta traduzione `"Map"` → `"Mappa"` in `resources/lang/it.json`.
+
+## Perché
+
+Il campo `FeatureCollectionMap` mostra la geometria complessiva del layer (bounding box + features). Collocarlo dentro "Ec Tracks" è semanticamente sbagliato: la mappa rappresenta il layer nel suo insieme, non solo le tracce. Inoltre la mappa non mostra gli EcPoi associati, rendendo incompleta la visione geografica del contenuto del layer dalla sua pagina di dettaglio.
+
+## Requisiti
+
+- [ ] `FeatureCollectionMap::make(__('Geometry'), 'geometry')->onlyOnDetail()` spostato in `Panel::make(__('Map'), [...])` separato
+- [ ] Il panel "Map" è posizionato prima di "Ec Tracks" e "Ec Pois" nel layout Nova
+- [ ] `Panel::make('Ec Tracks', [...])` contiene solo `LayerFeatures` per le tracce (senza `FeatureCollectionMap`)
+- [ ] `Layer::getFeatureCollectionMap()` carica le geometrie degli EcPoi associati via `layerables` con raw SQL (stesso pattern EcTrack)
+- [ ] Ogni EcPoi aggiunto alla mappa ha `tooltip` (nome), `link` (`nova/resources/ec-pois/{id}`); nessun colore esplicito (il Vue component applica i propri default: `pointFillColor: rgba(255,0,0,0.8)`, `pointRadius: 6`)
+- [ ] Traduzione `"Map"` aggiunta in `resources/lang/it.json` → `"Mappa"` e in `resources/lang/en.json` → `"Map"`
+- [ ] Test in `wm-package/tests/Feature/` che verificano: (a) EcPoi features presenti nel risultato di `getFeatureCollectionMap()` quando esistono EcPoi associati; (b) EcPoi senza geometria non producono features; (c) layer senza EcPoi non rompe il metodo
+
+## Rischi
+
+- **Nessun `ec_poi_table` in config** (a differenza di `ec_track_table`): il nome tabella va derivato da `(new EcPoi)->getTable()` o hardcodato come `ec_pois`. Soluzione: hardcode `ec_pois` + commento — è lo stesso approccio usato per `taxonomy_wheres` nello stesso metodo.
+- **Performance**: nessun limite al numero di EcPoi caricati (coerente con il comportamento esistente per EcTrack). Layer con migliaia di EcPoi potrebbero rallentare la risposta API — rischio accettato per design, allineato al pattern corrente.
+- **Dist JS non ricompilato**: tutte le modifiche sono PHP-only. Il Vue component `FeatureCollectionMap` già supporta geometrie `Point` e le renderizza con i default. Nessun rebuild necessario.
+
+## Out of scope
+
+- Stili EcPoi configurabili per layer (colore/dimensione punti personalizzabili dalla UI Nova)
+- Limite o paginazione degli EcPoi mostrati sulla mappa
+- Aggiunta di `ec_poi_table` alla configurazione del package
+- Modifica al Vue component `FeatureCollectionMap.vue`
+
+## Moduli toccati
+
+| Repo | File | Modifica |
+|---|---|---|
+| `wm-package` | `src/Nova/Layer.php` | Sposta `FeatureCollectionMap` in panel "Map"; rimuovilo da panel "Ec Tracks" |
+| `wm-package` | `src/Models/Layer.php` | `getFeatureCollectionMap()`: aggiunge loop EcPoi con query SQL + `addFeaturesForMap()` |
+| `wm-package` | `resources/lang/it.json` | Aggiunge `"Map": "Mappa"` |
+| `wm-package` | `resources/lang/en.json` | Aggiunge `"Map": "Map"` |
+| `wm-package` | `tests/Feature/LayerGetFeatureCollectionMapEcPoisTest.php` | Nuovo — test copertura logica EcPoi in `getFeatureCollectionMap()` |

--- a/docs/features/8160-layer-nova-map-panel-ec-poi/plan.md
+++ b/docs/features/8160-layer-nova-map-panel-ec-poi/plan.md
@@ -1,0 +1,157 @@
+> Ticket: oc:8160
+
+# Piano — Layer Nova: sposta Geometry fuori dal panel Ec Tracks e mostra anche EcPoi sulla mappa
+
+## Step 1 — Crea branch in wm-package
+
+```bash
+cd wm-package
+git checkout -b feature/oc-8160-layer-nova-map-panel-ec-poi
+```
+
+---
+
+## Step 2 — `src/Nova/Layer.php`: riposiziona FeatureCollectionMap in panel dedicato
+
+**File:** `wm-package/src/Nova/Layer.php`
+
+Sostituisci il blocco righe 96–106:
+
+```php
+// PRIMA
+Panel::make('Ec Tracks', [
+    FeatureCollectionMap::make(__('Geometry'), 'geometry')->onlyOnDetail(),
+    LayerFeatures::make(__('tracks'), $this->resource, config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack'))
+        ->hideWhenCreating()
+        ->withMeta(['model_class' => config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack')]),
+]),
+Panel::make('Ec Pois', [
+    LayerFeatures::make(__('pois'), $this->resource, config('wm-package.ec_poi_model', 'Wm\WmPackage\Models\EcPoi'))
+        ->hideWhenCreating()
+        ->withMeta(['model_class' => config('wm-package.ec_poi_model', 'Wm\WmPackage\Models\EcPoi')]),
+]),
+```
+
+Con:
+
+```php
+// DOPO
+Panel::make(__('Map'), [
+    FeatureCollectionMap::make(__('Geometry'), 'geometry')->onlyOnDetail(),
+]),
+Panel::make('Ec Tracks', [
+    LayerFeatures::make(__('tracks'), $this->resource, config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack'))
+        ->hideWhenCreating()
+        ->withMeta(['model_class' => config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack')]),
+]),
+Panel::make('Ec Pois', [
+    LayerFeatures::make(__('pois'), $this->resource, config('wm-package.ec_poi_model', 'Wm\WmPackage\Models\EcPoi'))
+        ->hideWhenCreating()
+        ->withMeta(['model_class' => config('wm-package.ec_poi_model', 'Wm\WmPackage\Models\EcPoi')]),
+]),
+```
+
+---
+
+## Step 3 — `resources/lang/it.json` e `en.json`: aggiungi traduzione "Map"
+
+**File:** `wm-package/resources/lang/it.json`
+
+Aggiungi prima della chiusura `}`:
+```json
+"Map": "Mappa"
+```
+
+**File:** `wm-package/resources/lang/en.json`
+
+Aggiungi prima della chiusura `}`:
+```json
+"Map": "Map"
+```
+
+---
+
+## Step 4 — `src/Models/Layer.php`: aggiungi EcPoi in `getFeatureCollectionMap()`
+
+**File:** `wm-package/src/Models/Layer.php`
+
+Subito dopo il blocco `if (! empty($trackIds)) { ... }` (riga ~412), prima del blocco `$whereIds = $this->taxonomyWheres()...`, aggiungi:
+
+```php
+$poiIds = $this->ecPois()->pluck('ec_pois.id')->toArray();
+
+if (! empty($poiIds)) {
+    $poiPlaceholders = implode(',', array_fill(0, count($poiIds), '?'));
+    $poiSql = "SELECT id, name, ST_AsGeoJSON(geometry) as geometry FROM ec_pois WHERE id IN ({$poiPlaceholders}) AND geometry IS NOT NULL";
+    $poiRows = DB::select($poiSql, $poiIds);
+
+    foreach ($poiRows as $ecPoi) {
+        $geometry = json_decode($ecPoi->geometry, true);
+        $nameData = json_decode($ecPoi->name, true);
+        $ecPoiName = $nameData['it'] ?? (is_array($nameData) && ! empty($nameData) ? reset($nameData) : 'Nome non disponibile');
+
+        if ($geometry) {
+            $this->addFeaturesForMap([[
+                'type' => 'Feature',
+                'geometry' => $geometry,
+                'properties' => [
+                    'tooltip' => $ecPoiName,
+                    'link' => url('nova/resources/ec-pois/'.$ecPoi->id),
+                ],
+            ]]);
+        }
+    }
+}
+```
+
+**Nota:** nessun colore esplicito nelle properties EcPoi — il Vue component applica i default (`pointFillColor: rgba(255,0,0,0.8)`, `pointRadius: 6`), identici a quanto visto nella pagina di dettaglio dell'EcPoi stesso.
+
+---
+
+## Step 5 — Test: `tests/Feature/LayerGetFeatureCollectionMapEcPoisTest.php`
+
+**File:** `wm-package/tests/Feature/LayerGetFeatureCollectionMapEcPoisTest.php` (nuovo)
+
+Usa `Wm\WmPackage\Tests\TestCase` e `DatabaseTransactions`. Crea il file con questi 3 casi:
+
+**Caso 1 — EcPoi con geometria → presente nella FeatureCollection**
+- Crea `App`, `Layer`, `EcPoi` con geometria Point (tramite factory + `DB::statement` raw per la geometria WKB, come negli altri test del package)
+- Inserisci in `layerables` la relazione Layer→EcPoi
+- Chiama `$layer->getFeatureCollectionMap()`
+- Asserisci: `type === 'FeatureCollection'`, features contiene almeno una feature con `geometry.type === 'Point'`, `properties.link` contiene `ec-pois/{id}`, `properties.tooltip` non è vuoto
+
+**Caso 2 — EcPoi senza geometria → non incluso nella FeatureCollection**
+- Crea EcPoi senza geometria (colonna `geometry` a NULL)
+- Inserisci in `layerables`
+- Chiama `$layer->getFeatureCollectionMap()`
+- Asserisci: nessuna feature Point nel risultato
+
+**Caso 3 — Layer senza EcPoi associati → metodo non crasha, restituisce FeatureCollection valida**
+- Crea Layer senza nulla in `layerables`
+- Chiama `$layer->getFeatureCollectionMap()`
+- Asserisci: ritorna array con `type === 'FeatureCollection'` e `features` è array (anche vuoto)
+
+Esegui i test con:
+```bash
+docker exec laravel-camminiditalia php artisan test wm-package/tests/Feature/LayerGetFeatureCollectionMapEcPoisTest.php
+```
+
+---
+
+## Step 6 — Verifica manuale in Nova
+
+- Apri la pagina di dettaglio di un Layer in Nova
+- Verifica che esista un panel "Mappa" (o "Map") separato con la mappa interattiva
+- Verifica che il panel "Ec Tracks" non contenga più la mappa
+- Verifica che punti rossi compaiano sulla mappa per gli EcPoi associati al layer
+- Clicca un punto → verifica che apra la scheda Nova dell'EcPoi in nuova tab
+
+---
+
+## Commit convention
+
+```
+feat(oc:8160): move Geometry to dedicated Map panel and show EcPoi on layer map
+```
+
+Unico commit che include tutti i file modificati nei step 2–5.

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -297,5 +297,6 @@
     "URL template for the tile server (e.g. https://example.com/{z}/{x}/{y}.png)": "URL template for the tile server (e.g. https://example.com/{z}/{x}/{y}.png)",
     "Link used over the attribution tag in the app (optional)": "Link used over the attribution tag in the app (optional)",
     "Where": "Where",
-    "Wheres": "Wheres"
+    "Wheres": "Wheres",
+    "Map": "Map"
 }

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -298,5 +298,6 @@
     "Link used over the attribution tag in the app (optional)": "Link usato sul tag di attribution nell'app (opzionale)",
     "Where": "Luogo",
     "Wheres": "Luoghi",
-    "Requires authentication at startup to be enabled": "Richiede che l'autenticazione all'avvio sia attiva"
+    "Requires authentication at startup to be enabled": "Richiede che l'autenticazione all'avvio sia attiva",
+    "Map": "Mappa"
 }

--- a/src/Models/Layer.php
+++ b/src/Models/Layer.php
@@ -411,6 +411,31 @@ class Layer extends Polygon
             }
         }
 
+        $poiIds = $this->ecPois()->pluck('ec_pois.id')->toArray();
+
+        if (! empty($poiIds)) {
+            $poiPlaceholders = implode(',', array_fill(0, count($poiIds), '?'));
+            $poiSql = "SELECT id, name, ST_AsGeoJSON(geometry) as geometry FROM ec_pois WHERE id IN ({$poiPlaceholders}) AND geometry IS NOT NULL";
+            $poiRows = DB::select($poiSql, $poiIds);
+
+            foreach ($poiRows as $ecPoi) {
+                $geometry = json_decode($ecPoi->geometry, true);
+                $nameData = json_decode($ecPoi->name, true);
+                $ecPoiName = $nameData['it'] ?? (is_array($nameData) && ! empty($nameData) ? reset($nameData) : 'Nome non disponibile');
+
+                if ($geometry) {
+                    $this->addFeaturesForMap([[
+                        'type' => 'Feature',
+                        'geometry' => $geometry,
+                        'properties' => [
+                            'tooltip' => $ecPoiName,
+                            'link' => url('nova/resources/ec-pois/'.$ecPoi->id),
+                        ],
+                    ]]);
+                }
+            }
+        }
+
         $whereIds = $this->taxonomyWheres()->pluck('taxonomy_wheres.id')->toArray();
         if (! empty($whereIds)) {
             $placeholders = implode(',', array_fill(0, count($whereIds), '?'));

--- a/src/Models/Layer.php
+++ b/src/Models/Layer.php
@@ -411,14 +411,15 @@ class Layer extends Polygon
             }
         }
 
+        $poiNovaResourceName = 'ec-pois';
         $poiIds = $this->ecPois()->pluck('ec_pois.id')->toArray();
 
         if (! empty($poiIds)) {
-            $poiPlaceholders = implode(',', array_fill(0, count($poiIds), '?'));
-            $poiSql = "SELECT id, name, ST_AsGeoJSON(geometry) as geometry FROM ec_pois WHERE id IN ({$poiPlaceholders}) AND geometry IS NOT NULL";
-            $poiRows = DB::select($poiSql, $poiIds);
+            $placeholders = implode(',', array_fill(0, count($poiIds), '?'));
+            $sql = "SELECT id, name, ST_AsGeoJSON(geometry) as geometry FROM ec_pois WHERE id IN ({$placeholders}) AND geometry IS NOT NULL";
+            $rows = DB::select($sql, $poiIds);
 
-            foreach ($poiRows as $ecPoi) {
+            foreach ($rows as $ecPoi) {
                 $geometry = json_decode($ecPoi->geometry, true);
                 $nameData = json_decode($ecPoi->name, true);
                 $ecPoiName = $nameData['it'] ?? (is_array($nameData) && ! empty($nameData) ? reset($nameData) : 'Nome non disponibile');
@@ -429,7 +430,7 @@ class Layer extends Polygon
                         'geometry' => $geometry,
                         'properties' => [
                             'tooltip' => $ecPoiName,
-                            'link' => url('nova/resources/ec-pois/'.$ecPoi->id),
+                            'link' => url('nova/resources/'.$poiNovaResourceName.'/'.$ecPoi->id),
                         ],
                     ]]);
                 }

--- a/src/Nova/Layer.php
+++ b/src/Nova/Layer.php
@@ -93,8 +93,10 @@ class Layer extends AbstractGeometryResource
             MorphToMany::make(__('Activities'), 'taxonomyActivities', TaxonomyActivity::class),
             MorphToMany::make('Taxonomy Where', 'taxonomyWheres', TaxonomyWhere::class)
                 ->actions(fn () => []),
-            Panel::make('Ec Tracks', [
+            Panel::make(__('Map'), [
                 FeatureCollectionMap::make(__('Geometry'), 'geometry')->onlyOnDetail(),
+            ]),
+            Panel::make('Ec Tracks', [
                 LayerFeatures::make(__('tracks'), $this->resource, config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack'))
                     ->hideWhenCreating()
                     ->withMeta(['model_class' => config('wm-package.ec_track_model', 'Wm\WmPackage\Models\EcTrack')]),

--- a/tests/Feature/LayerGetFeatureCollectionMapEcPoisTest.php
+++ b/tests/Feature/LayerGetFeatureCollectionMapEcPoisTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Wm\WmPackage\Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\EcPoi;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Tests\TestCase;
+
+class LayerGetFeatureCollectionMapEcPoisTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_ec_poi_with_geometry_appears_as_point_feature_in_map(): void
+    {
+        $app = App::factory()->createQuietly();
+        $layer = Layer::factory()->createQuietly(['app_id' => $app->id]);
+        $poi = EcPoi::factory()->createQuietly(['app_id' => $app->id]);
+
+        $layer->ecPois()->attach($poi->id);
+
+        $result = $layer->fresh()->getFeatureCollectionMap();
+
+        $this->assertSame('FeatureCollection', $result['type']);
+
+        $pointFeatures = array_values(array_filter($result['features'], function ($f) {
+            return isset($f['geometry']['type']) && $f['geometry']['type'] === 'Point';
+        }));
+
+        $this->assertNotEmpty($pointFeatures, 'Nessuna feature Point trovata nella FeatureCollection');
+
+        $feature = $pointFeatures[0];
+        $this->assertArrayHasKey('tooltip', $feature['properties']);
+        $this->assertNotEmpty($feature['properties']['tooltip']);
+        $this->assertStringContainsString('ec-pois/'.$poi->id, $feature['properties']['link']);
+    }
+
+    public function test_ec_poi_without_geometry_is_not_included_in_map(): void
+    {
+        $app = App::factory()->createQuietly();
+        $layer = Layer::factory()->createQuietly(['app_id' => $app->id]);
+        $poi = EcPoi::factory()->createQuietly(['app_id' => $app->id]);
+
+        DB::table('ec_pois')->where('id', $poi->id)->update(['geometry' => null]);
+
+        $layer->ecPois()->attach($poi->id);
+
+        $result = $layer->fresh()->getFeatureCollectionMap();
+
+        $pointFeatures = array_filter($result['features'], function ($f) {
+            return isset($f['geometry']['type']) && $f['geometry']['type'] === 'Point';
+        });
+
+        $this->assertEmpty($pointFeatures, 'EcPoi senza geometria non dovrebbe produrre feature Point');
+    }
+
+    public function test_layer_without_ec_pois_returns_valid_feature_collection(): void
+    {
+        $app = App::factory()->createQuietly();
+        $layer = Layer::factory()->createQuietly(['app_id' => $app->id]);
+
+        $result = $layer->fresh()->getFeatureCollectionMap();
+
+        $this->assertSame('FeatureCollection', $result['type']);
+        $this->assertIsArray($result['features']);
+    }
+}


### PR DESCRIPTION
## Summary

- Sposta `FeatureCollectionMap` (campo Geometry) fuori da `Panel::make('Ec Tracks', [...])` in un panel dedicato `Panel::make(__('Map'), [...])`  posizionato prima di "Ec Tracks" e "Ec Pois"
- Estende `Layer::getFeatureCollectionMap()` per includere le geometrie degli EcPoi associati al layer (via tabella `layerables`), con tooltip sul nome e link alla scheda Nova del POI — pattern identico a EcTrack
- Aggiunge traduzione `"Map"` → `"Mappa"` in `it.json` / `"Map"` in `en.json`

## Test plan

- [ ] Aprire pagina di dettaglio di un Layer in Nova — verificare presenza panel "Mappa" separato con mappa interattiva
- [ ] Verificare che il panel "Ec Tracks" non contenga più il campo mappa
- [ ] Verificare che punti rossi compaiano sulla mappa per gli EcPoi associati al layer
- [ ] Cliccare un punto EcPoi → verifica apertura scheda Nova `ec-pois/{id}` in nuova tab
- [ ] Layer senza EcPoi → mappa funzionante, solo tracce visibili
- [ ] Test unitari: `wm-package/tests/Feature/LayerGetFeatureCollectionMapEcPoisTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)