### PR TITLE
feat(migrations): gate publish-missing-migrations con confronto schema DB oc:8218

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,35 @@ protected static function newFactory(): Factory
 | Refactor SuperAdminService | oc:8006 | `src/Services/RolesAndPermissionsService.php`, `src/Support/SuperAdminService.php` (rimosso), `src/Nova/App.php`, `src/Nova/Actions/GenerateAppIconsAction.php`, `src/Nova/Actions/BuildAppPoisGeojsonAction.php`, `src/Policies/AppPolicy.php` | Sposta i check super-admin email-based in RolesAndPermissionsService; rimuove SuperAdminService |
 | Fix esposizione assets API | oc:7913 | `src/Http/Controllers/Api/AppController.php` | `getOrDownloadIcon` usa `getMedia()->first()` invece di `isset($app->$type)` — fix 404 su app con media in Spatie e colonne null |
 | Modifica ruolo utente in Nova | oc:8072 | `src/Nova/AbstractUserResource.php`, `tests/Feature/Nova/AbstractUserResourceRoleGuardTest.php` | Guard `RolesAndPermissionsService::allowsUser()` su ruoli/permessi; fillUsing server-side; anti-self-demotion |
+| Comandi migration stub wm-package | oc:8218 | `src/Commands/WmPackage{PublishMigration,PublishMissingMigrations}Command.php`, `src/Commands/Concerns/InteractsWithWmPackageMigrationStubs.php` | Stub obbligatori. CI: `publish-missing-migrations --dry-run`. Dev: `publish-missing-migrations` / `publish-migration`. Suffisso file non basta |
 
 ## Decisioni architetturali
+
+### Comandi migration stub wm-package (oc:8218)
+
+**Fonte di verità:** `docs/features/8218-cicd-migration-wm-package-permission-cache/overview.md`. Pipeline CI end-to-end: overview maphub (`maphub/docs/features/8218-.../overview.md`).
+
+- Stub in `database/migrations/*.php.stub` **obbligatori** per ogni consumer
+- **`publish-missing-migrations --dry-run`** — gate CI consumer (dopo `migrate`, stesso DB dei test); exit 1 se non allineato
+- **`publish-missing-migrations`** — workflow dev: pubblica stub con gap schema e senza file identico committato
+- **`publish-migration <stub>`** — singolo stub; non si ferma al suffisso se contenuto diverso (es. `create_users_table`)
+- Mai `vendor:publish` in deploy; mai `vendor:publish --force` in locale
+
+**Logica per stub** (`InteractsWithWmPackageMigrationStubs`):
+- `schemaGapsForStub` → colonne/tabelle/ruoli mancanti sul DB
+- `isAppliedToDatabase` → nessun gap (o migration eseguita per suffisso se stub non parsabile)
+- `needsPublishing` → gap + nessun file committato identico allo stub
+- `stubsPendingMigration` → file identico committato ma non in tabella `migrations`
+
+**Tabella casi d'uso (agenti):**
+
+| Scenario | `--dry-run` | Azione |
+|----------|-------------|--------|
+| Schema già completo | pass | Nessuna |
+| Gap schema, nessun file identico | fail | `publish-missing-migrations` / `publish-migration` |
+| File identico in git, non migrato | fail | `migrate` |
+| Suffisso uguale, contenuto diverso | fail | Pubblica stub wm-package |
+| Schema ok via migration custom | pass | Nessuna |
 
 ### Import Layer: associazione EcPoi via taxonomy (oc:8043)
 - `associateLayersWithEcPoi()` controlla tre meccanismi GeoHub in sequenza: `taxonomy_themeables`, `taxonomy_whereables`, `taxonomy_poi_typeables` — **taxonomy_theme è il meccanismo primario** (app 63: 48/11/4 poi; app 44: 101-109 poi per layer)
@@ -153,6 +180,27 @@ protected static function newFactory(): Factory
 - I metodi `allows()`, `allowsUser()`, `allowsEmail()` vivono in `RolesAndPermissionsService` — punto unico per logica di autorizzazione nel package
 - `SuperAdminService` è stata rimossa senza alias deprecato: breaking change da comunicare nel changelog prima di ogni rilascio
 - I metodi sono statici (non DI) per coerenza con il pattern preesistente; la logica legge solo `config('wm-package.super_admin_emails')` senza stato interno
+
+## Migration wm-package (stub obbligatori)
+
+Valido per ogni consumer (maphub, camminiditalia, osm2cai2, ...). Overview completa: `docs/features/8218-cicd-migration-wm-package-permission-cache/overview.md`.
+
+### Workflow
+
+```bash
+php artisan wm-package:publish-missing-migrations --dry-run
+php artisan wm-package:publish-missing-migrations   # se exit 1
+php artisan migrate
+git add database/migrations/ && git commit
+```
+
+### Se `--dry-run` fallisce
+
+1. Leggi stub in `database/migrations/<nome>.php.stub` (questo package)
+2. Cerca migration equivalente nel consumer (per **contenuto/schema**, non nome)
+3. Schema già allineato → nessuna azione
+4. Gap sul DB → `publish-migration <stub>` o `publish-missing-migrations` + `migrate` + commit
+5. File identico committato ma non migrato → `php artisan migrate`
 
 ## Documentazione
 

--- a/docs/features/8218-cicd-migration-wm-package-permission-cache/notes.md
+++ b/docs/features/8218-cicd-migration-wm-package-permission-cache/notes.md
@@ -1,0 +1,15 @@
+> Ticket: oc:8218
+
+# Notes — comandi migration stub wm-package
+
+## Comandi
+
+- `publish-missing-migrations` (+ `--dry-run` = gate CI consumer)
+- `publish-migration <stub>` — singolo stub, ignora falsi positivi da suffisso
+
+## Review
+
+- `publish-migration` rifiuta se schema già applicato o file identico non migrato
+- `create_users_table`: suffisso Laravel maschera stub wm-package — `--dry-run` lo rileva
+
+Pipeline e casi d'uso end-to-end: `maphub/docs/features/8218-cicd-migration-wm-package-permission-cache/overview.md`.

--- a/docs/features/8218-cicd-migration-wm-package-permission-cache/overview.md
+++ b/docs/features/8218-cicd-migration-wm-package-permission-cache/overview.md
@@ -1,0 +1,114 @@
+> Ticket: oc:8218
+
+# Comandi wm-package per migration stub obbligatori
+
+## Design finale
+
+Il ticket oc:8218 (lato consumer) chiedeva `vendor:publish` in deploy + gate CI filesystem. Implementazione attuale:
+
+- **Niente publish in deploy** — file migration solo via git
+- **Gate CI** — `publish-missing-migrations --dry-run` dopo `migrate` (stesso DB dei test)
+- **Stub obbligatori** — verifica semantica sullo schema DB, non suffisso file
+
+Pipeline CI/CD e casi d'uso end-to-end: `maphub/docs/features/8218-cicd-migration-wm-package-permission-cache/overview.md`.
+
+---
+
+## Diagramma gate per stub
+
+```mermaid
+flowchart TD
+    stub[Stub wm-package] --> gaps{Schema DB ha gap?}
+    gaps -->|No| ok[Allineato]
+    gaps -->|Sì| identical{File committato identico allo stub?}
+    identical -->|Sì| migrated{Già in tabella migrations?}
+    migrated -->|No| pending[stubsPendingMigration]
+    migrated -->|Sì| ok
+    identical -->|No| publish[needsPublishing]
+```
+
+---
+
+## Comandi
+
+| Comando | DB | Ruolo |
+|---------|-----|--------|
+| `wm-package:publish-missing-migrations` | Sì | Workflow principale: pubblica stub il cui effetto manca sul DB |
+| `wm-package:publish-missing-migrations --dry-run` | Sì | Gate CI consumer; exit non-zero se non allineato |
+| `wm-package:publish-migration <stub>` | Sì | Publish singolo stub; ignora falsi positivi da suffisso |
+
+---
+
+## `publish-missing-migrations` — logica
+
+Per ogni `*.php.stub` in `database/migrations/` del package:
+
+1. Estrae tabelle/colonne/ruoli attesi (parser euristico su `Schema::create/table`, `insertOrIgnore` ruoli)
+2. Confronta con **schema DB reale** del consumer (`schemaGapsForStub`)
+3. Se **nessun gap** → stub allineato (`isAppliedToDatabase`)
+4. Se gap **e** esiste file committato **identico** allo stub → `stubsPendingMigration` (serve `migrate`)
+5. Se gap **e** nessun file identico → `needsPublishing` → pubblica `database/migrations/<timestamp>_<stub>.php`
+
+### `--dry-run`
+
+- Exit `0` se tutti gli stub allineati
+- Exit `1` se `needsPublishing` o `stubsPendingMigration` non vuoti
+- Elenca stub e gap (`manca colonna users.balance`, ecc.)
+
+---
+
+## `publish-migration <stub>` — differenza da suffisso
+
+Non si ferma se esiste un file con lo **stesso suffisso** ma **contenuto diverso** (es. `0001_..._create_users_table.php` Laravel vs stub wm-package con `Schema::table`).
+
+Ordine dei controlli:
+
+1. Stub esiste?
+2. Schema già applicato? → exit `0`, nessuna azione
+3. File identico committato ma non migrato? → exit `1`, suggerisce `migrate`
+4. Altrimenti pubblica (anche con suffisso diverso o contenuto diverso)
+
+---
+
+## Casi d'uso (lato comando)
+
+| Scenario | `needsPublishing` | `stubsPendingMigration` | `--dry-run` | Azione |
+|----------|-------------------|-------------------------|-------------|--------|
+| Schema già completo sul DB | false | false | pass | Nessuna |
+| Gap schema, nessun file identico | true | false | fail | `publish-missing-migrations` o `publish-migration` |
+| File identico in git, non migrato | false | true | fail | `migrate` |
+| Suffisso uguale, contenuto diverso (`create_users_table`) | true | false | fail | Pubblica stub wm-package |
+| Schema già ok via migration custom (nome diverso) | false | false | pass | Nessuna |
+
+---
+
+## Trait condiviso
+
+`InteractsWithWmPackageMigrationStubs` centralizza:
+
+- Lookup stub e file pubblicati (suffisso e contenuto)
+- `schemaGapsForStub`, `isAppliedToDatabase`, `needsPublishing`
+- `publishStubToProject`
+
+---
+
+## Requisiti
+
+- [x] Due comandi registrati in `WmPackageServiceProvider`
+- [x] Trait condiviso
+- [x] `--dry-run` con exit code per gate CI
+- [x] `publish-migration` ignora suffisso se contenuto diverso
+- [x] Test Feature
+
+## Rischi
+
+- Parser schema dagli stub — euristica; stub con sole FK/indici senza colonne estratte usano fallback su migration eseguita per suffisso
+- Deploy manuale senza CI — non mitigabile senza restrizioni container
+
+## Moduli toccati
+
+- `src/Commands/Concerns/InteractsWithWmPackageMigrationStubs.php`
+- `src/Commands/WmPackagePublishMigrationCommand.php`
+- `src/Commands/WmPackagePublishMissingMigrationsCommand.php`
+- `src/WmPackageServiceProvider.php`
+- `tests/Feature/WmPackagePublish*CommandTest.php`, `InteractsWithWmPackageMigrationStubsTest.php`

--- a/docs/features/8218-cicd-migration-wm-package-permission-cache/plan.md
+++ b/docs/features/8218-cicd-migration-wm-package-permission-cache/plan.md
@@ -1,0 +1,11 @@
+> Ticket: oc:8218
+
+# Comandi wm-package per migration stub obbligatori
+
+Questo piano è stato **superato**. Non eseguirlo.
+
+**Fonte di verità (package):** [`overview.md`](./overview.md) — comandi, logica trait, casi d'uso.
+
+**Pipeline CI end-to-end:** overview del repo consumer (es. maphub: `docs/features/8218-cicd-migration-wm-package-permission-cache/overview.md`).
+
+Note: [`notes.md`](./notes.md).

--- a/src/Commands/Concerns/InteractsWithWmPackageMigrationStubs.php
+++ b/src/Commands/Concerns/InteractsWithWmPackageMigrationStubs.php
@@ -1,0 +1,331 @@
+<?php
+
+namespace Wm\WmPackage\Commands\Concerns;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+trait InteractsWithWmPackageMigrationStubs
+{
+    /**
+     * @return array<int, string>
+     */
+    public function stubBaseNames(): array
+    {
+        $paths = glob($this->stubsDirectory().'/*.stub') ?: [];
+
+        return array_map(
+            fn (string $path) => $this->baseNameFromStubPath($path),
+            $paths,
+        );
+    }
+
+    public function findStubPath(string $baseName): ?string
+    {
+        $path = $this->stubsDirectory()."/{$baseName}.php.stub";
+
+        return file_exists($path) ? $path : null;
+    }
+
+    /**
+     * Mirrors the suffix-matching logic used internally by
+     * Spatie\LaravelPackageTools\Concerns\PackageServiceProvider\ProcessMigrations::generateMigrationName()
+     * so a file already published by `vendor:publish` is always recognised here.
+     */
+    public function findPublishedFilenameForStub(string $baseName): ?string
+    {
+        $path = $this->findPublishedPathForStub($baseName);
+
+        return $path !== null ? basename($path, '.php') : null;
+    }
+
+    public function findPublishedPathForStub(string $baseName): ?string
+    {
+        $needle = "{$baseName}.php";
+        $needleLength = strlen($needle);
+
+        foreach (glob(database_path('migrations/*.php')) ?: [] as $path) {
+            if (! is_file($path)) {
+                continue;
+            }
+
+            if (substr($path, -$needleLength) === $needle) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function findPublishedPathsMatchingStubContent(string $baseName): array
+    {
+        $stubPath = $this->findStubPath($baseName);
+
+        if ($stubPath === null) {
+            return [];
+        }
+
+        $normalizedStub = $this->normalizeMigrationPhp(file_get_contents($stubPath));
+        $matches = [];
+
+        foreach (glob(database_path('migrations/*.php')) ?: [] as $path) {
+            if (! is_file($path)) {
+                continue;
+            }
+
+            if ($this->normalizeMigrationPhp(file_get_contents($path)) === $normalizedStub) {
+                $matches[] = $path;
+            }
+        }
+
+        return $matches;
+    }
+
+    public function publishedFileMatchesStubContent(string $baseName): bool
+    {
+        return $this->findPublishedPathsMatchingStubContent($baseName) !== [];
+    }
+
+    public function normalizeMigrationPhp(string $content): string
+    {
+        $content = preg_replace('/\r\n/', "\n", $content) ?? $content;
+        $content = preg_replace('/\s+/', ' ', $content) ?? $content;
+
+        return trim($content);
+    }
+
+    protected function stubsDirectory(): string
+    {
+        return dirname(__DIR__, 3).'/database/migrations';
+    }
+
+    protected function baseNameFromStubPath(string $path): string
+    {
+        return Str::of(basename($path))->replace(['.stub', '.php'], '')->toString();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function schemaGapsForStub(string $baseName): array
+    {
+        $stubPath = $this->findStubPath($baseName);
+
+        if ($stubPath === null) {
+            return ["stub \"{$baseName}\" non trovato"];
+        }
+
+        $gaps = [];
+        $content = file_get_contents($stubPath);
+
+        foreach ($this->extractSchemaExpectations($content) as $table => $info) {
+            if (! Schema::hasTable($table)) {
+                $gaps[] = "manca tabella {$table}";
+
+                continue;
+            }
+
+            foreach ($info['columns'] as $column) {
+                if (! Schema::hasColumn($table, $column)) {
+                    $gaps[] = "manca colonna {$table}.{$column}";
+                }
+            }
+        }
+
+        foreach ($this->extractRoleExpectations($content) as $roleName) {
+            if (! DB::table('roles')->where('name', $roleName)->exists()) {
+                $gaps[] = "manca ruolo {$roleName}";
+            }
+        }
+
+        return $gaps;
+    }
+
+    public function isAppliedToDatabase(string $baseName): bool
+    {
+        if ($this->findStubPath($baseName) === null) {
+            return false;
+        }
+
+        $gaps = $this->schemaGapsForStub($baseName);
+
+        if ($gaps !== []) {
+            return false;
+        }
+
+        if ($this->hasVerifiableSchemaExpectations($baseName)) {
+            return true;
+        }
+
+        return $this->hasRunPublishedMigrationForStub($baseName);
+    }
+
+    public function needsPublishing(string $baseName): bool
+    {
+        if ($this->findStubPath($baseName) === null) {
+            return false;
+        }
+
+        if ($this->isAppliedToDatabase($baseName)) {
+            return false;
+        }
+
+        return ! $this->publishedFileMatchesStubContent($baseName);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function stubsNeedingPublishing(): array
+    {
+        return array_values(array_filter(
+            $this->stubBaseNames(),
+            fn (string $baseName) => $this->needsPublishing($baseName),
+        ));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function stubsPendingMigration(): array
+    {
+        return array_values(array_filter(
+            $this->stubBaseNames(),
+            fn (string $baseName) => $this->publishedFileMatchesStubContent($baseName)
+                && ! $this->hasRunPublishedMigrationForStub($baseName),
+        ));
+    }
+
+    public function publishStubToProject(string $baseName): string
+    {
+        $stubPath = $this->findStubPath($baseName);
+
+        if ($stubPath === null) {
+            throw new \InvalidArgumentException("Nessuno stub trovato per \"{$baseName}\".");
+        }
+
+        $timestamp = now()->format('Y_m_d_His');
+        $destination = database_path("migrations/{$timestamp}_{$baseName}.php");
+
+        if (! copy($stubPath, $destination)) {
+            throw new \RuntimeException("Impossibile pubblicare lo stub in {$destination}.");
+        }
+
+        return $destination;
+    }
+
+    /**
+     * @return array<string, array{op: string, columns: array<int, string>}>
+     */
+    protected function extractSchemaExpectations(string $content): array
+    {
+        $expected = [];
+
+        if (! preg_match_all(
+            '/Schema::(create|table)\(\s*[\'"]([^\'"]+)[\'"]/s',
+            $content,
+            $matches,
+            PREG_OFFSET_CAPTURE,
+        )) {
+            return $expected;
+        }
+
+        foreach ($matches[0] as $index => $fullMatch) {
+            $operation = $matches[1][$index][0];
+            $table = $matches[2][$index][0];
+            $start = $fullMatch[1];
+            $slice = substr($content, $start, 4000);
+
+            $columns = [];
+            if (preg_match_all(
+                '/\$table->(?!foreign|index|unique|primary|drop|timestamps|rememberToken|comment|softDeletes|morphs|uuid|constrained|nullable|default|after|change|renameColumn)\w*\(\s*[\'"]([^\'"]+)[\'"]/',
+                $slice,
+                $columnMatches,
+            )) {
+                $columns = array_values(array_unique($columnMatches[1]));
+            }
+
+            if (preg_match('/\$table->id\(/', $slice)) {
+                $columns[] = 'id';
+            }
+
+            if (preg_match('/\$table->morphs\(\s*[\'"]([^\'"]+)[\'"]/', $slice, $morphMatch)) {
+                $columns[] = $morphMatch[1].'_type';
+                $columns[] = $morphMatch[1].'_id';
+            }
+
+            $expected[$table] = [
+                'op' => $operation,
+                'columns' => array_values(array_unique($columns)),
+            ];
+        }
+
+        return $expected;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function extractRoleExpectations(string $content): array
+    {
+        if (! str_contains($content, 'insertOrIgnore') && ! str_contains($content, 'Role::')) {
+            return [];
+        }
+
+        if (! preg_match_all("/['\"]name['\"]\s*=>\s*['\"]([^'\"]+)['\"]/", $content, $matches)) {
+            return [];
+        }
+
+        return array_values(array_unique($matches[1]));
+    }
+
+    protected function hasVerifiableSchemaExpectations(string $baseName): bool
+    {
+        $stubPath = $this->findStubPath($baseName);
+
+        if ($stubPath === null) {
+            return false;
+        }
+
+        $content = file_get_contents($stubPath);
+        $schema = $this->extractSchemaExpectations($content);
+
+        foreach ($schema as $info) {
+            if ($info['columns'] !== []) {
+                return true;
+            }
+        }
+
+        return $this->extractRoleExpectations($content) !== [];
+    }
+
+    protected function hasRunPublishedMigrationMatchingStubContent(string $baseName): bool
+    {
+        foreach ($this->findPublishedPathsMatchingStubContent($baseName) as $path) {
+            if (DB::table('migrations')->where('migration', basename($path, '.php'))->exists()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function hasRunPublishedMigrationForStub(string $baseName): bool
+    {
+        if ($this->hasRunPublishedMigrationMatchingStubContent($baseName)) {
+            return true;
+        }
+
+        $path = $this->findPublishedPathForStub($baseName);
+
+        if ($path === null) {
+            return false;
+        }
+
+        return DB::table('migrations')->where('migration', basename($path, '.php'))->exists();
+    }
+}

--- a/src/Commands/WmPackagePublishMigrationCommand.php
+++ b/src/Commands/WmPackagePublishMigrationCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Wm\WmPackage\Commands;
+
+use Illuminate\Console\Command;
+use Wm\WmPackage\Commands\Concerns\InteractsWithWmPackageMigrationStubs;
+
+class WmPackagePublishMigrationCommand extends Command
+{
+    use InteractsWithWmPackageMigrationStubs;
+
+    protected $signature = 'wm-package:publish-migration {stub : Nome-base dello stub, senza estensione}';
+
+    protected $description = 'Pubblica un singolo stub di migration del wm-package non ancora presente nel progetto.';
+
+    public function handle(): int
+    {
+        $baseName = $this->argument('stub');
+
+        if ($this->findStubPath($baseName) === null) {
+            $this->error("Nessuno stub trovato per \"{$baseName}\".");
+
+            return self::FAILURE;
+        }
+
+        if ($this->isAppliedToDatabase($baseName)) {
+            $this->info("\"{$baseName}\" risulta gia' applicata sul database, nessuna azione.");
+
+            return self::SUCCESS;
+        }
+
+        if ($this->publishedFileMatchesStubContent($baseName)) {
+            $this->warn("\"{$baseName}\" ha gia' una migration committata equivalente allo stub ma non ancora applicata sul database.");
+            $this->line('Esegui: php artisan migrate');
+
+            return self::FAILURE;
+        }
+
+        if ($this->findPublishedFilenameForStub($baseName) !== null) {
+            $this->line("\"{$baseName}\" ha un file con lo stesso suffisso ma contenuto diverso dallo stub: pubblico la migration corretta del wm-package.");
+        }
+
+        try {
+            $destination = $this->publishStubToProject($baseName);
+        } catch (\Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Pubblicata: {$destination}");
+        $this->line('Ricorda di committare il file pubblicato: la migration deve arrivare sul server via git, mai generata durante il deploy.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/WmPackagePublishMissingMigrationsCommand.php
+++ b/src/Commands/WmPackagePublishMissingMigrationsCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Wm\WmPackage\Commands;
+
+use Illuminate\Console\Command;
+use Wm\WmPackage\Commands\Concerns\InteractsWithWmPackageMigrationStubs;
+
+class WmPackagePublishMissingMigrationsCommand extends Command
+{
+    use InteractsWithWmPackageMigrationStubs;
+
+    protected $signature = 'wm-package:publish-missing-migrations
+                            {--dry-run : Elenca stub non allineati; exit code non-zero se ce ne sono (gate CI)}';
+
+    protected $description = 'Pubblica gli stub wm-package obbligatori il cui effetto non e\' ancora presente nel database.';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $toPublish = $this->stubsNeedingPublishing();
+        $pendingMigrate = $this->stubsPendingMigration();
+
+        if ($pendingMigrate !== []) {
+            $this->warn('Stub con migration gia\' pubblicata ma non ancora applicata sul database:');
+            foreach ($pendingMigrate as $baseName) {
+                $this->line("  - {$baseName}");
+            }
+            $this->line('  Esegui: php artisan migrate');
+            $this->newLine();
+        }
+
+        if ($toPublish === [] && $pendingMigrate === []) {
+            $this->info('Tutti gli stub wm-package obbligatori risultano allineati al database.');
+
+            return self::SUCCESS;
+        }
+
+        if ($toPublish !== []) {
+            $this->error(sprintf(
+                '%s %d stub non allineati al database (manca migration committata equivalente):',
+                $dryRun ? '[dry-run]' : 'Pubblico',
+                count($toPublish),
+            ));
+
+            foreach ($toPublish as $baseName) {
+                $this->line("  - {$baseName}");
+                foreach ($this->schemaGapsForStub($baseName) as $gap) {
+                    $this->line("      {$gap}");
+                }
+            }
+
+            $this->newLine();
+        }
+
+        if ($dryRun) {
+            $this->line('Risolvi in locale: php artisan wm-package:publish-missing-migrations, migrate, commit, push.');
+
+            return self::FAILURE;
+        }
+
+        $published = 0;
+
+        foreach ($toPublish as $baseName) {
+            try {
+                $destination = $this->publishStubToProject($baseName);
+                $this->info("Pubblicata: {$destination}");
+                $published++;
+            } catch (\Throwable $exception) {
+                $this->error("Errore su {$baseName}: {$exception->getMessage()}");
+
+                return self::FAILURE;
+            }
+        }
+
+        if ($pendingMigrate !== []) {
+            $this->line('Esegui php artisan migrate per applicare le migration gia\' committate.');
+
+            return self::FAILURE;
+        }
+
+        $this->newLine();
+        $this->line('Ricorda di committare i file pubblicati e poi eseguire php artisan migrate.');
+
+        return $published > 0 ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/src/WmPackageServiceProvider.php
+++ b/src/WmPackageServiceProvider.php
@@ -26,6 +26,8 @@ use Wm\WmPackage\Commands\WmGenerateIconsCommand;
 use Wm\WmPackage\Commands\WmGeneratePBFCommand;
 use Wm\WmPackage\Commands\WmImportFromGeohubCommand;
 use Wm\WmPackage\Commands\WmPackageCommand;
+use Wm\WmPackage\Commands\WmPackagePublishMigrationCommand;
+use Wm\WmPackage\Commands\WmPackagePublishMissingMigrationsCommand;
 use Wm\WmPackage\Commands\WmRestoreDbCommand;
 use Wm\WmPackage\Commands\WmSyncUgcTaxonomyWhereCommand;
 use Wm\WmPackage\ElasticSearch\HitsIteratorAggregate as ElasticSearchHitsIteratorAggregate;
@@ -196,6 +198,8 @@ class WmPackageServiceProvider extends PackageServiceProvider
                 WmSyncUgcTaxonomyWhereCommand::class,
                 WmRestoreDbCommand::class,
                 WmGenerateIconsCommand::class,
+                WmPackagePublishMigrationCommand::class,
+                WmPackagePublishMissingMigrationsCommand::class,
             ])
             ->hasViews();
     }

--- a/tests/Feature/InteractsWithWmPackageMigrationStubsTest.php
+++ b/tests/Feature/InteractsWithWmPackageMigrationStubsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Wm\WmPackage\Tests\Feature;
+
+use Tests\TestCase;
+use Wm\WmPackage\Commands\Concerns\InteractsWithWmPackageMigrationStubs;
+
+class InteractsWithWmPackageMigrationStubsTest extends TestCase
+{
+    private object $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new class
+        {
+            use InteractsWithWmPackageMigrationStubs;
+        };
+    }
+
+    public function test_stub_base_names_returns_at_least_one_real_stub(): void
+    {
+        $names = $this->subject->stubBaseNames();
+
+        $this->assertNotEmpty($names);
+        $this->assertContains('zz_2026_06_26_000001_add_editor_role', $names);
+    }
+
+    public function test_find_published_filename_for_stub_matches_by_suffix(): void
+    {
+        $found = $this->subject->findPublishedFilenameForStub('zz_2026_06_26_000001_add_editor_role');
+
+        $this->assertNotNull($found);
+        $this->assertStringEndsWith('zz_2026_06_26_000001_add_editor_role', $found);
+    }
+
+    public function test_find_published_filename_for_stub_returns_null_when_not_published(): void
+    {
+        $found = $this->subject->findPublishedFilenameForStub('zz_9999_99_99_999999_never_published');
+
+        $this->assertNull($found);
+    }
+
+    public function test_create_users_table_is_not_applied_to_database_on_maphub(): void
+    {
+        $this->assertFalse($this->subject->isAppliedToDatabase('create_users_table'));
+        $this->assertTrue($this->subject->needsPublishing('create_users_table'));
+        $this->assertContains('manca colonna users.balance', $this->subject->schemaGapsForStub('create_users_table'));
+    }
+}

--- a/tests/Feature/WmPackagePublishMigrationCommandTest.php
+++ b/tests/Feature/WmPackagePublishMigrationCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Wm\WmPackage\Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class WmPackagePublishMigrationCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private string $fakeStubPath;
+
+    private string $baseName = 'zz_9999_99_99_999998_publish_for_test';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fakeStubPath = base_path("wm-package/database/migrations/{$this->baseName}.php.stub");
+        File::put($this->fakeStubPath, "<?php\nreturn new class extends \Illuminate\Database\Migrations\Migration {\n    public function up(): void {}\n    public function down(): void {}\n};\n");
+    }
+
+    protected function tearDown(): void
+    {
+        File::delete($this->fakeStubPath);
+
+        foreach (glob(database_path('migrations/*_'.$this->baseName.'.php')) ?: [] as $published) {
+            File::delete($published);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_publishes_a_specific_stub(): void
+    {
+        $this->artisan('wm-package:publish-migration', ['stub' => $this->baseName])
+            ->assertExitCode(0);
+
+        $matches = glob(database_path('migrations/*_'.$this->baseName.'.php'));
+
+        $this->assertNotEmpty($matches);
+    }
+
+    public function test_fails_for_unknown_stub(): void
+    {
+        $this->artisan('wm-package:publish-migration', ['stub' => 'not_a_real_stub'])
+            ->assertExitCode(1);
+    }
+}

--- a/tests/Feature/WmPackagePublishMissingMigrationsCommandTest.php
+++ b/tests/Feature/WmPackagePublishMissingMigrationsCommandTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Wm\WmPackage\Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class WmPackagePublishMissingMigrationsCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private string $fakeStubPath;
+
+    private string $baseName = 'zz_9999_99_99_999996_missing_publish_for_test';
+
+    private string $conflictingPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fakeStubPath = base_path("wm-package/database/migrations/{$this->baseName}.php.stub");
+        $this->conflictingPath = database_path('migrations/0001_01_01_000000_'.$this->baseName.'.php');
+
+        File::put($this->fakeStubPath, <<<'PHP'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('zz_9999_99_99_999996_missing_publish_for_test_flag')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('zz_9999_99_99_999996_missing_publish_for_test_flag');
+        });
+    }
+};
+PHP);
+
+        File::put($this->conflictingPath, <<<'PHP'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('wrong_suffix_only')->nullable();
+        });
+    }
+
+    public function down(): void {}
+};
+PHP);
+    }
+
+    protected function tearDown(): void
+    {
+        File::delete($this->fakeStubPath);
+        File::delete($this->conflictingPath);
+
+        foreach (glob(database_path('migrations/*_'.$this->baseName.'.php')) ?: [] as $published) {
+            if ($published !== $this->conflictingPath) {
+                File::delete($published);
+            }
+        }
+
+        foreach (glob(database_path('migrations/*_create_users_table.php')) ?: [] as $published) {
+            if (! str_ends_with($published, '0001_01_01_000000_create_users_table.php')) {
+                File::delete($published);
+            }
+        }
+
+        if (Schema::hasColumn('users', 'zz_9999_99_99_999996_missing_publish_for_test_flag')) {
+            Schema::table('users', function ($table) {
+                $table->dropColumn('zz_9999_99_99_999996_missing_publish_for_test_flag');
+            });
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_dry_run_lists_stub_with_wrong_suffix_file_and_missing_db_columns(): void
+    {
+        $this->artisan('wm-package:publish-missing-migrations', ['--dry-run' => true])
+            ->assertExitCode(1)
+            ->expectsOutputToContain($this->baseName);
+    }
+
+    public function test_publishes_stub_even_when_suffix_file_has_different_content(): void
+    {
+        $this->artisan('wm-package:publish-migration', ['stub' => $this->baseName])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('Pubblicata:');
+
+        $matches = array_filter(
+            glob(database_path('migrations/*_'.$this->baseName.'.php')) ?: [],
+            fn (string $path) => $path !== $this->conflictingPath,
+        );
+
+        $this->assertCount(1, $matches);
+        $this->assertStringContainsString(
+            'zz_9999_99_99_999996_missing_publish_for_test_flag',
+            file_get_contents(array_values($matches)[0]),
+        );
+    }
+
+    public function test_publish_migration_publishes_create_users_table_despite_laravel_suffix_file(): void
+    {
+        $this->assertFalse(Schema::hasColumn('users', 'balance'));
+
+        $this->artisan('wm-package:publish-migration', ['stub' => 'create_users_table'])
+            ->assertExitCode(0)
+            ->expectsOutputToContain('contenuto diverso')
+            ->expectsOutputToContain('Pubblicata:');
+
+        $matches = array_filter(
+            glob(database_path('migrations/*_create_users_table.php')) ?: [],
+            fn (string $path) => ! str_ends_with($path, '0001_01_01_000000_create_users_table.php'),
+        );
+
+        $this->assertCount(1, $matches);
+        $this->assertStringContainsString('balance', file_get_contents(array_values($matches)[0]));
+    }
+}


### PR DESCRIPTION
## Summary
- Aggiunge `wm-package:publish-migration` e `wm-package:publish-missing-migrations` con opzione `--dry-run` per il gate CI
- Il confronto avviene sullo **schema DB reale** (colonne/indici mancanti), non solo sul suffisso del file migration
- Include test Pest e documentazione feature in `docs/features/8218-cicd-migration-wm-package-permission-cache/`

## Test plan
- [x] `php artisan test wm-package/tests/Feature/WmPackagePublishMigrationCommandTest.php`
- [x] `php artisan test wm-package/tests/Feature/WmPackagePublishMissingMigrationsCommandTest.php`
- [x] `php artisan test wm-package/tests/Feature/InteractsWithWmPackageMigrationStubsTest.php`
- [ ] Merge wm-package **prima** della PR maphub (submodule punta a questo commit)


Made with [Cursor](https://cursor.com)