### PR TITLE
feat(oc:8176): add favorite layers (backend)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,8 +145,15 @@ protected static function newFactory(): Factory
 | Comandi migration stub wm-package | oc:8218 | `src/Commands/WmPackage{PublishMigration,PublishMissingMigrations}Command.php`, `src/Commands/Concerns/InteractsWithWmPackageMigrationStubs.php` | Stub obbligatori. CI: `publish-missing-migrations --dry-run`. Dev: `publish-missing-migrations` / `publish-migration`. Suffisso file non basta |
 | Toggle QR code deep link + well-known registry | oc:8251 | `src/Models/App.php`, `src/Nova/App.php`, `src/Nova/EcTrack.php`, `src/Nova/EcPoi.php`, `src/Services/WellKnownRegistryService.php`, `src/Observers/AppObserver.php`, `config/wm-package.php`, `config/wm-filesystems.php` | Toggle `native_app_deep_link_enabled` per app (rinominato da `qr_code_deep_link_enabled` in corso d'opera) + field QR/deep-link su Track/Poi (Nova Field, non Action) + sync automatico file well-known (apple-app-site-association/assetlinks.json) via SFTP |
 | Condivisione percorso su Instagram/Facebook Stories | oc:8183 | `src/Models/App.php`, `src/Nova/App.php`, `src/Services/Models/App/AppConfigService.php`, `src/Http/Controllers/Api/ShareStoryImageController.php`, `src/Services/Models/StoryShare/{StoryImageLayout,StoryShareImageService}.php`, `routes/api.php` | Media collection `story_frame` su App (Nova upload); endpoint stateless `POST /api/share-story-image` deriva l'app da `UgcTrack` (uuid) con ownership check, mai da parametro client; compositing 1080x1920 via intervention/image |
+| Preferiti layer (backend) | oc:8176 | `src/Models/Layer.php`, `src/Http/Controllers/Api/LayerFavoriteController.php` (nuovo), `routes/api.php`, `src/Services/Models/App/AppConfigService.php`, `src/Nova/App.php` | Trait `Favoriteable` mirror di EcTrack; endpoint `layer/favorite/{add,remove,toggle,list}`; flag `show_favorites` in `properties` (nessuna migration), esposto come `OPTIONS.showFavorites` (camelCase). Dettagli in `docs/features/8176-salva-cammino-nei-preferiti/notes.md` |
 
 ## Decisioni architetturali
+
+### Preferiti layer (oc:8176)
+- **Nessuno scoping `app_id` sugli endpoint `layer/favorite/*`**: decisione esplicita del developer, il legame è Layer↔App non Layer↔Utente, coerente con `EcTrackController` (comportamento preesistente, non introdotto qui)
+- **`show_favorites` vive in `properties` JSON dell'App, non in una colonna**: la chiave esposta in `OPTIONS` di config.json è `showFavorites` (camelCase), diversa dalla chiave di storage `properties->show_favorites` (snake_case, invariata) — scelta esplicita del developer per coerenza con lo stile prevalente di `OPTIONS`
+- **Campo Nova "Show favorites" vive nel tab "Frontend" (`app_tab()`), non "Home"**: spostato su richiesta esplicita del developer, subito sotto "Ugc Track Share Enabled"
+- **`LayerFavoriteController::list()` usa `MediaService::getThumbnailUrl()`** (conversione 400×200), non `getFirstMediaUrl()` diretto — pattern consolidato altrove nel codebase (`AppConfigService.php`, `EcTrack.php`) per risposte "leggere", mancante nella prima versione e corretto in review formale
 
 ### Condivisione percorso su Instagram/Facebook Stories (oc:8183)
 

--- a/docs/features/8176-salva-cammino-nei-preferiti/notes.md
+++ b/docs/features/8176-salva-cammino-nei-preferiti/notes.md
@@ -1,0 +1,24 @@
+> Ticket: oc:8176
+
+# Notes — Salva cammino nei preferiti (wm-package)
+
+## Deviazioni dal piano
+
+**Posizione del campo Nova spostata**: il campo Boolean `Show favorites` (`properties->show_favorites`) era stato inizialmente collocato nel tab "Home" (`home_tab()`, accanto a `Show searchbar`). Su richiesta esplicita del developer, spostato nel tab "Frontend" (`app_tab()`), subito dopo `Ugc Track Share Enabled` — stesso raggruppamento degli altri flag opt-in lato frontend (`show_travel_mode`, `ugc_track_share_enabled`). Nessun impatto su `AppConfigService`/test, solo riposizionamento del campo Nova.
+
+## Bug trovati
+
+Nessuno lato backend. Il bug del cuoricino invisibile (classi CSS icona errate) e il successivo redesign sola-lettura/interattivo sono interamente lato frontend — vedi `wm-core`.
+
+## Decisioni
+
+Vedi `overview.md` — decisione esplicita di non aggiungere scoping `app_id` sugli endpoint `layer/favorite/*` (Layer↔App, non Layer↔Utente), confermata dal developer in Fase: challenge.
+
+## Review formale (`wm-skills:wm-review-ticket`) — finding corretto
+
+**[blocker] `feature_image` serviva il file originale invece della thumbnail 400×200** — `LayerFavoriteController::list()` usava `$layer->getFirstMediaUrl('default')`, restituendo l'URL del media non processato. Il pattern consolidato altrove nel codebase per lo stesso tipo di risposta "leggera" (`AppConfigService.php`, `EcTrack.php:739`) usa invece `MediaService::make()->getThumbnailUrl($media)` (conversione Spatie 400×200). Corretto per coerenza — file potenzialmente molto più pesante altrimenti, senza garanzia di aspect ratio per il box che si aspetta un crop coerente.
+
+## Follow-up
+
+- Endpoint `add`/`remove` senza consumer reale oggi (solo `toggle` usato dal frontend) — vedi `wm-core/notes.md`.
+- TOCTOU non atomico su `addFavorite`/`removeFavorite` (check-poi-toggle) — pattern replicato identico da `EcTrackController`, non introdotto da questo ciclo, non risolto (debito preesistente accettato).

--- a/docs/features/8176-salva-cammino-nei-preferiti/overview.md
+++ b/docs/features/8176-salva-cammino-nei-preferiti/overview.md
@@ -1,0 +1,44 @@
+> Ticket: oc:8176
+
+# Salva cammino nei preferiti — wm-package
+
+## Cosa cambia
+
+Il modello `Layer` diventa "favoritabile" tramite il trait `Favoriteable` di `ChristianKuri\LaravelFavorite` — lo stesso pacchetto già usato da `EcTrack`, sulla stessa tabella `favorites` polimorfica già esistente su `camminiditalia` (nessuna nuova migration).
+
+Nuovo controller `LayerController` (o metodi aggiunti a `LayerAPIController`) che replica esattamente il pattern già in produzione per `EcTrackController`: `addFavorite`/`removeFavorite`/`toggleFavorite` (auth:api) su un singolo layer, più un endpoint `list` — ma a differenza del pattern `EcTrack` (che ritorna solo ID), questo ritorna una lista **leggera di oggetti Layer completi** (`id`, `title`/`name`, `feature_image`, `logo_image`, `style.color`), non l'intero `AppController::layer()` (che include tracce annidate, non necessario qui). Questa singola chiamata serve sia a popolare la lista "I miei preferiti" sia — cacheata client-side — a determinare se un singolo layer è tra i preferiti (stesso pattern già usato da `GeohubService.favourites()` per le tracce: nessun flag `is_favorited` embedded in nessuna risposta layer).
+
+Il flag `show_favorites`, già letto (ma orfano) in `AppConfigService.php:745` (`$this->app->show_favorites`), viene spostato dentro `properties` JSON dell'`App` (pattern già usato per altri flag recenti, es. `apple_team_id`, `android_cert_sha256`) — **nessuna migration/colonna nuova**. Default `false`; il developer lo abiliterà manualmente per Cammini d'Italia da Nova dopo il merge. Nuovo campo Boolean in `src/Nova/App.php` che legge/scrive `properties->show_favorites`.
+
+## Perché
+
+Estendere ai `Layer` (cammini) un'infrastruttura preferiti già completa e in produzione per `EcTrack` (tracce) — vedi `webmapp-app/docs/features/8176-salva-cammino-nei-preferiti/overview.md` per il contesto frontend completo (tab "Favourites" già esistente, oggi solo tracce).
+
+## Requisiti
+
+- [ ] Trait `Favoriteable` (`ChristianKuri\LaravelFavorite`) aggiunto a `Wm\WmPackage\Models\Layer`
+- [ ] Route `POST /api/layer/favorite/add/{layer}`, `POST /api/layer/favorite/remove/{layer}`, `POST /api/layer/favorite/toggle/{layer}` — `middleware('auth:api')`, mirror esatto di `EcTrackController` (stesso response shape `{'favorite': bool}`)
+- [ ] Route `GET /api/layer/favorite/list` — ritorna array di oggetti Layer leggeri (`id`, `title`/`name`, `feature_image`, `logo_image`, `style.color`), non solo ID
+- [ ] `show_favorites` spostato in `properties` JSON dell'`App` — nessuna migration; default `false`
+- [x] Campo Nova Boolean (`src/Nova/App.php`) per `properties->show_favorites` — vive nel tab **"Frontend"** (`app_tab()`), subito sotto `Ugc Track Share Enabled`, non nel tab "Home" (spostato su richiesta esplicita del developer dopo il primo giro di implementazione)
+- [x] `AppConfigService::config_section_options()` aggiornato per leggere `$this->app->properties['show_favorites'] ?? false` invece della colonna inesistente — **la chiave esposta in `OPTIONS` di config.json è `showFavorites` (camelCase)**, non `show_favorites`: solo la chiave di storage in `properties` (Nova, DB) resta snake_case, su richiesta esplicita del developer per coerenza con lo stile prevalentemente camelCase di `OPTIONS`
+
+## Rischi
+
+- **Nessun rischio di migration condivisa**: verificato che la tabella `favorites` esiste già su `camminiditalia` (usata da `EcTrack`) — il rischio originale del ticket è di fatto già risolto
+- **`show_favorites` era già scritto (dead code) in `AppConfigService.php` da gennaio 2025** senza mai avere una sorgente dati — nessuna app ha mai ricevuto questo flag finora; il cambio non causa regressioni, ma va verificato che nessun frontend/consumer facesse già affidamento (silenzioso) su un `show_favorites: null`
+- **Nessuno scoping per `app_id` sugli endpoint `layer/favorite/*`** (emerso in Fase: challenge, analogo al pattern già esistente — non introdotto — per `EcTrackController`): confermato esplicitamente dal developer che il legame è Layer↔App, non Layer↔Utente — un utente vede solo i layer della propria app, quindi non serve alcuna verifica aggiuntiva di ownership. Nessuna azione richiesta su questo punto; annotato solo per tracciabilità della decisione
+
+## Out of scope
+
+- Preferiti su `EcPoi`
+- Qualsiasi nuovo campo/migration sulla tabella `apps` (si usa `properties` JSON)
+- Endpoint pubblico "get layer by id" generico (fuori scope di questo ticket, anche se emerso come gap architetturale durante l'analisi — vedi notes.md)
+
+## Moduli toccati
+
+- `src/Models/Layer.php` — trait `Favoriteable`
+- `src/Http/Controllers/Api/LayerController.php` (nuovo) o estensione `LayerAPIController.php`
+- `routes/api.php` — nuovo blocco `layer/favorite/*`
+- `src/Services/Models/App/AppConfigService.php` — lettura `show_favorites` da `properties`
+- `src/Nova/App.php` — campo Boolean `properties->show_favorites`

--- a/docs/features/8176-salva-cammino-nei-preferiti/plan.md
+++ b/docs/features/8176-salva-cammino-nei-preferiti/plan.md
@@ -1,0 +1,427 @@
+# Salva cammino nei preferiti — wm-package Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> Ticket: oc:8176
+
+**Goal:** Rendere `Layer` favoritabile (stesso meccanismo già in produzione per `EcTrack`) ed esporre il flag `show_favorites` (spostato in `properties` JSON, nessuna migration) che condiziona la UI frontend.
+
+**Architecture:** Mirror 1:1 del pattern `EcTrackController`/`ChristianKuri\LaravelFavorite` già esistente, riusando la tabella `favorites` polimorfica già presente. Nessuna nuova migration in tutto il piano.
+
+**Tech Stack:** Laravel, `christiankuri/laravel-favorite` (già installato), Pest (test), Nova (campo Boolean).
+
+## Global Constraints
+
+- Nessuna migration in nessun task di questo piano (tabella `favorites` già esiste; `show_favorites` va in `properties` JSON, non in una colonna)
+- Nessuno scoping/verifica ownership `app_id` sugli endpoint `layer/favorite/*` — decisione esplicita del developer (Layer↔App, non Layer↔Utente), coerente col comportamento già esistente di `EcTrackController`
+- Guard di autenticazione: `middleware('auth:api')`, risoluzione utente via `auth('api')->id()`/`auth('api')->user()` — mai il guard web di default
+- Test in stile Pest (funzioni `it(...)`), `Wm\WmPackage\Tests\TestCase` applicato globalmente da `tests/Pest.php` — nessun `uses()` esplicito necessario nei nuovi file
+- Il response shape del toggle deve restare `{'favorite': bool}`, identico a `EcTrackController::toggleFavorite` — il frontend (wm-core) fa un aggiornamento ottimistico basato su questo valore
+
+---
+
+### Task 1: Trait `Favoriteable` su `Layer`
+
+**Files:**
+- Modify: `src/Models/Layer.php:1-25` (namespace `use` + dichiarazione `use` dei trait sulla classe)
+- Test: `tests/Feature/LayerFavoriteModelTest.php` (nuovo)
+
+**Interfaces:**
+- Consumes: nessuno (primo task)
+- Produces: `Layer::addFavorite($userId)`, `Layer::removeFavorite($userId)`, `Layer::toggleFavorite($userId)`, `Layer::isFavorited($userId)` — metodi del trait `ChristianKuri\LaravelFavorite\Traits\Favoriteable`, usati dai Task 2 e 3
+
+- [ ] **Step 1: Scrivi il test che verifica il trait**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Models\User;
+
+it('allows a user to favorite and unfavorite a layer', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+
+    expect($layer->isFavorited($user->id))->toBeFalse();
+
+    $layer->toggleFavorite($user->id);
+    expect($layer->fresh()->isFavorited($user->id))->toBeTrue();
+
+    $layer->toggleFavorite($user->id);
+    expect($layer->fresh()->isFavorited($user->id))->toBeFalse();
+});
+```
+
+- [ ] **Step 2: Esegui il test per verificare che fallisca**
+
+Run: `vendor/bin/pest tests/Feature/LayerFavoriteModelTest.php`
+Expected: FAIL — `Call to undefined method Wm\WmPackage\Models\Layer::isFavorited()`
+
+- [ ] **Step 3: Aggiungi il trait a `Layer`**
+
+In `src/Models/Layer.php`, aggiungi l'import subito dopo `use App\Models\User;`:
+
+```php
+use ChristianKuri\LaravelFavorite\Traits\Favoriteable;
+```
+
+Poi aggiorna la dichiarazione `use` della classe (riga `use FeatureCollectionMapTrait, HasPackageFactory, HasTranslations, NormalizesHexColor, TaxonomyAbleModel, TaxonomyWhereAbleModel;`):
+
+```php
+use Favoriteable, FeatureCollectionMapTrait, HasPackageFactory, HasTranslations, NormalizesHexColor, TaxonomyAbleModel, TaxonomyWhereAbleModel;
+```
+
+- [ ] **Step 4: Esegui il test per verificare che passi**
+
+Run: `vendor/bin/pest tests/Feature/LayerFavoriteModelTest.php`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Models/Layer.php tests/Feature/LayerFavoriteModelTest.php
+git commit -m "feat(oc:8176): add Favoriteable trait to Layer model"
+```
+
+---
+
+### Task 2: Endpoint `add`/`remove`/`toggle` preferito layer
+
+**Files:**
+- Create: `src/Http/Controllers/Api/LayerFavoriteController.php`
+- Modify: `routes/api.php` (nuovo blocco route, vicino al blocco esistente `ec/track/favorite/*` righe 126-134)
+- Test: `tests/Feature/LayerFavoriteControllerTest.php` (nuovo)
+
+**Interfaces:**
+- Consumes: `Layer::addFavorite()`/`removeFavorite()`/`toggleFavorite()`/`isFavorited()` (Task 1)
+- Produces: `POST /api/layer/favorite/add/{layer}`, `POST /api/layer/favorite/remove/{layer}`, `POST /api/layer/favorite/toggle/{layer}` — tutte rispondono `{'favorite': bool}`, consumato dal frontend wm-core per l'aggiornamento ottimistico
+
+- [ ] **Step 1: Scrivi i test che verificano i tre endpoint**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Models\User;
+
+it('rejects an unauthenticated toggle request', function () {
+    $app = App::factory()->createQuietly();
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+
+    $response = $this->postJson("/api/layer/favorite/toggle/{$layer->id}");
+
+    $response->assertStatus(401);
+});
+
+it('adds a layer to favorites and is idempotent on repeated add', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+    $this->actingAs($user, 'api');
+
+    $response = $this->postJson("/api/layer/favorite/add/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => true]);
+
+    $response = $this->postJson("/api/layer/favorite/add/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => true]);
+
+    expect($layer->fresh()->isFavorited($user->id))->toBeTrue();
+});
+
+it('removes a layer from favorites and is idempotent on repeated remove', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+    $layer->toggleFavorite($user->id);
+    $this->actingAs($user, 'api');
+
+    $response = $this->postJson("/api/layer/favorite/remove/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => false]);
+
+    $response = $this->postJson("/api/layer/favorite/remove/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => false]);
+
+    expect($layer->fresh()->isFavorited($user->id))->toBeFalse();
+});
+
+it('toggles a layer favorite state back and forth', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+    $this->actingAs($user, 'api');
+
+    $response = $this->postJson("/api/layer/favorite/toggle/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => true]);
+
+    $response = $this->postJson("/api/layer/favorite/toggle/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => false]);
+});
+```
+
+- [ ] **Step 2: Esegui i test per verificare che falliscano**
+
+Run: `vendor/bin/pest tests/Feature/LayerFavoriteControllerTest.php`
+Expected: FAIL — 404 Not Found (route inesistente)
+
+- [ ] **Step 3: Crea il controller**
+
+```php
+<?php
+
+namespace Wm\WmPackage\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Wm\WmPackage\Http\Controllers\Controller;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Models\User;
+
+class LayerFavoriteController extends Controller
+{
+    /**
+     * Add the given layer to the authenticated user's favorites (idempotent).
+     */
+    public function addFavorite(Request $request, Layer $layer): JsonResponse
+    {
+        $userId = auth('api')->id();
+        if (! $layer->isFavorited($userId)) {
+            $layer->toggleFavorite($userId);
+        }
+
+        return response()->json(['favorite' => $layer->isFavorited($userId)]);
+    }
+
+    /**
+     * Remove the given layer from the authenticated user's favorites (idempotent).
+     */
+    public function removeFavorite(Request $request, Layer $layer): JsonResponse
+    {
+        $userId = auth('api')->id();
+        if ($layer->isFavorited($userId)) {
+            $layer->toggleFavorite($userId);
+        }
+
+        return response()->json(['favorite' => $layer->isFavorited($userId)]);
+    }
+
+    /**
+     * Toggle the favorite state of the given layer for the authenticated user.
+     */
+    public function toggleFavorite(Request $request, Layer $layer): JsonResponse
+    {
+        $userId = auth('api')->id();
+        $layer->toggleFavorite($userId);
+
+        return response()->json(['favorite' => $layer->isFavorited($userId)]);
+    }
+}
+```
+
+- [ ] **Step 4: Aggiungi le route**
+
+In `routes/api.php`, subito dopo il blocco esistente (righe 126-134, dentro `Route::prefix('track')`), aggiungi un nuovo blocco fratello al prefisso `ec` esistente (fuori dal gruppo `ec/track`, come nuovo top-level `layer`):
+
+```php
+Route::prefix('layer')->name('layer.')->group(function () {
+    Route::middleware('auth:api')
+        ->prefix('favorite')->name('favorite.')->group(function () {
+            Route::post('/add/{layer}', [LayerFavoriteController::class, 'addFavorite'])->name('add');
+            Route::post('/remove/{layer}', [LayerFavoriteController::class, 'removeFavorite'])->name('remove');
+            Route::post('/toggle/{layer}', [LayerFavoriteController::class, 'toggleFavorite'])->name('toggle');
+        });
+});
+```
+
+Aggiungi l'import in cima al file: `use Wm\WmPackage\Http\Controllers\Api\LayerFavoriteController;`
+
+- [ ] **Step 5: Esegui i test per verificare che passino**
+
+Run: `vendor/bin/pest tests/Feature/LayerFavoriteControllerTest.php`
+Expected: PASS (4 test)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Http/Controllers/Api/LayerFavoriteController.php routes/api.php tests/Feature/LayerFavoriteControllerTest.php
+git commit -m "feat(oc:8176): add layer favorite add/remove/toggle endpoints"
+```
+
+---
+
+### Task 3: Endpoint `list` (layer preferiti, payload leggero)
+
+**Files:**
+- Modify: `src/Http/Controllers/Api/LayerFavoriteController.php`
+- Modify: `routes/api.php`
+- Test: `tests/Feature/LayerFavoriteControllerTest.php`
+
+**Interfaces:**
+- Consumes: `User::favorite(Layer::class)` (da `ChristianKuri\LaravelFavorite\Traits\Favoriteability`, già presente su `User`), `Layer::getTranslations('name')`, `Layer::getFirstMediaUrl('default')`, `Layer::logo_image`, `Layer::getStrokeColorHex()`
+- Produces: `GET /api/layer/favorite/list` → `{'favorites': [{id, title, feature_image, logo_image, style: {color}}, ...]}` — consumato sia dal cuoricino (check `is_favorited`) sia dal tab "Cammini" in `FavouritesPage` (webmapp-app)
+
+- [ ] **Step 1: Scrivi il test per l'endpoint list**
+
+```php
+it('lists the authenticated user favorite layers with a lightweight payload', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $favorited = Layer::factory()->create(['app_id' => $app->id, 'name' => ['it' => 'Cammino preferito', 'en' => 'Favorite path']]);
+    $notFavorited = Layer::factory()->create(['app_id' => $app->id]);
+    $favorited->toggleFavorite($user->id);
+    $this->actingAs($user, 'api');
+
+    $response = $this->getJson('/api/layer/favorite/list');
+
+    $response->assertOk();
+    $favorites = $response->json('favorites');
+    expect($favorites)->toHaveCount(1);
+    expect($favorites[0]['id'])->toBe($favorited->id);
+    expect($favorites[0]['title']['it'])->toBe('Cammino preferito');
+    expect($favorites[0])->toHaveKeys(['id', 'title', 'feature_image', 'logo_image', 'style']);
+    expect(collect($favorites)->pluck('id'))->not->toContain($notFavorited->id);
+});
+```
+
+- [ ] **Step 2: Esegui il test per verificare che fallisca**
+
+Run: `vendor/bin/pest tests/Feature/LayerFavoriteControllerTest.php`
+Expected: FAIL — 404 Not Found (route `list` inesistente)
+
+- [ ] **Step 3: Aggiungi il metodo `list` al controller**
+
+In `src/Http/Controllers/Api/LayerFavoriteController.php`, aggiungi:
+
+```php
+    /**
+     * List the authenticated user's favorite layers with a lightweight payload
+     * (only the fields consumed by wm-layer-box: id, title, feature_image, logo_image, style.color).
+     */
+    public function list(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = auth('api')->user();
+
+        $layers = $user->favorite((new Layer)->getMorphClass())
+            ->map(function (Layer $layer) {
+                return [
+                    'id' => $layer->id,
+                    'title' => $layer->getTranslations('name'),
+                    'feature_image' => $layer->getFirstMediaUrl('default'),
+                    'logo_image' => $layer->logo_image,
+                    'style' => ['color' => $layer->getStrokeColorHex()],
+                ];
+            })
+            ->values();
+
+        return response()->json(['favorites' => $layers]);
+    }
+```
+
+- [ ] **Step 4: Aggiungi la route**
+
+In `routes/api.php`, dentro il gruppo `Route::prefix('layer')->prefix('favorite')` creato al Task 2:
+
+```php
+            Route::get('/list', [LayerFavoriteController::class, 'list'])->name('list');
+```
+
+- [ ] **Step 5: Esegui i test per verificare che passino**
+
+Run: `vendor/bin/pest tests/Feature/LayerFavoriteControllerTest.php`
+Expected: PASS (5 test)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Http/Controllers/Api/LayerFavoriteController.php routes/api.php tests/Feature/LayerFavoriteControllerTest.php
+git commit -m "feat(oc:8176): add lightweight layer favorites list endpoint"
+```
+
+---
+
+### Task 4: Flag `show_favorites` in `properties` JSON dell'App
+
+**Files:**
+- Modify: `src/Services/Models/App/AppConfigService.php:745`
+- Modify: `src/Nova/App.php` (tab `home_tab()`, vicino al campo `show_search`)
+- Test: `tests/Feature/AppConfigShowFavoritesTest.php` (nuovo)
+
+**Interfaces:**
+- Consumes: `$this->app->properties` (array, già castato su `App`)
+- Produces: `config.json → OPTIONS.show_favorites: bool`, consumato dal frontend (`confOPTIONSShowFavorites`, wm-core — fuori scope di questo repo)
+
+- [ ] **Step 1: Scrivi il test per il valore di default e per il valore impostato**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Services\Models\App\AppConfigService;
+
+it('defaults show_favorites to false when not set in properties', function () {
+    $app = App::factory()->createQuietly(['properties' => []]);
+
+    $config = (new AppConfigService($app))->config();
+
+    expect($config['OPTIONS']['show_favorites'])->toBeFalse();
+});
+
+it('reads show_favorites true from properties', function () {
+    $app = App::factory()->createQuietly(['properties' => ['show_favorites' => true]]);
+
+    $config = (new AppConfigService($app))->config();
+
+    expect($config['OPTIONS']['show_favorites'])->toBeTrue();
+});
+```
+
+- [ ] **Step 2: Esegui i test per verificare che falliscano**
+
+Run: `vendor/bin/pest tests/Feature/AppConfigShowFavoritesTest.php`
+Expected: FAIL — `show_favorites` risulta `null` invece di `false`/`true` (legge ancora la colonna inesistente)
+
+- [ ] **Step 3: Aggiorna `AppConfigService::config_section_options()`**
+
+In `src/Services/Models/App/AppConfigService.php`, sostituisci la riga 745:
+
+```php
+        $data['OPTIONS']['show_favorites'] = $this->app->show_favorites;
+```
+
+con:
+
+```php
+        $data['OPTIONS']['show_favorites'] = (bool) ($this->app->properties['show_favorites'] ?? false);
+```
+
+- [ ] **Step 4: Esegui i test per verificare che passino**
+
+Run: `vendor/bin/pest tests/Feature/AppConfigShowFavoritesTest.php`
+Expected: PASS
+
+- [ ] **Step 5: Aggiungi il campo Nova**
+
+In `src/Nova/App.php`, nel metodo `home_tab()`, subito dopo il campo `Boolean::make(__('Show searchbar'), 'show_search')...`:
+
+```php
+            Boolean::make(__('Show favorites'), 'properties->show_favorites')
+                ->default(false)
+                ->hideFromIndex()
+                ->help(__('Activate to show the favorite heart on layers and the "My favorites" section')),
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/Models/App/AppConfigService.php src/Nova/App.php tests/Feature/AppConfigShowFavoritesTest.php
+git commit -m "feat(oc:8176): read show_favorites from app properties instead of missing column"
+```

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,7 @@ use Wm\WmPackage\Http\Controllers\Api\EcPoiController;
 use Wm\WmPackage\Http\Controllers\Api\EcTrackController;
 use Wm\WmPackage\Http\Controllers\Api\EditorialContentController;
 use Wm\WmPackage\Http\Controllers\Api\ElasticsearchController;
+use Wm\WmPackage\Http\Controllers\Api\LayerFavoriteController;
 use Wm\WmPackage\Http\Controllers\Api\MediaController;
 use Wm\WmPackage\Http\Controllers\Api\ShareStoryImageController;
 use Wm\WmPackage\Http\Controllers\Api\UgcPoiController;
@@ -147,6 +148,20 @@ Route::name('api.')->group(function () {
             Route::get('/{id}.kml', [EditorialContentController::class, 'viewEcKml'])->name('view.kml');
             Route::get('/{ecTrack}', [EcTrackController::class, 'getGeojson'])->name('json');
         });
+    });
+
+    /**
+     * Layer favorites (oc:8176) — no app_id scoping/ownership check, same as ec/track/favorite
+     * above: Layer<->App, not Layer<->User, per explicit developer decision.
+     */
+    Route::prefix('layer')->name('layer.')->group(function () {
+        Route::middleware('auth:api')
+            ->prefix('favorite')->name('favorite.')->group(function () {
+                Route::post('/add/{layer}', [LayerFavoriteController::class, 'addFavorite'])->name('add');
+                Route::post('/remove/{layer}', [LayerFavoriteController::class, 'removeFavorite'])->name('remove');
+                Route::post('/toggle/{layer}', [LayerFavoriteController::class, 'toggleFavorite'])->name('toggle');
+                Route::get('/list', [LayerFavoriteController::class, 'list'])->name('list');
+            });
     });
 
     Route::post('search', [WebmappAppController::class, 'search'])->name('search');

--- a/src/Http/Controllers/Api/LayerFavoriteController.php
+++ b/src/Http/Controllers/Api/LayerFavoriteController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Wm\WmPackage\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Wm\WmPackage\Http\Controllers\Controller;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Models\User;
+use Wm\WmPackage\Services\Models\MediaService;
+
+class LayerFavoriteController extends Controller
+{
+    /**
+     * Add the given layer to the authenticated user's favorites (idempotent).
+     */
+    public function addFavorite(Request $request, Layer $layer): JsonResponse
+    {
+        $userId = auth('api')->id();
+        if (! $layer->isFavorited($userId)) {
+            $layer->toggleFavorite($userId);
+        }
+
+        return response()->json(['favorite' => $layer->isFavorited($userId)]);
+    }
+
+    /**
+     * Remove the given layer from the authenticated user's favorites (idempotent).
+     */
+    public function removeFavorite(Request $request, Layer $layer): JsonResponse
+    {
+        $userId = auth('api')->id();
+        if ($layer->isFavorited($userId)) {
+            $layer->toggleFavorite($userId);
+        }
+
+        return response()->json(['favorite' => $layer->isFavorited($userId)]);
+    }
+
+    /**
+     * Toggle the favorite state of the given layer for the authenticated user.
+     */
+    public function toggleFavorite(Request $request, Layer $layer): JsonResponse
+    {
+        $userId = auth('api')->id();
+        $layer->toggleFavorite($userId);
+
+        return response()->json(['favorite' => $layer->isFavorited($userId)]);
+    }
+
+    /**
+     * List the authenticated user's favorite layers with a lightweight payload
+     * (only the fields consumed by wm-layer-box: id, title, feature_image, logo_image, style.color).
+     */
+    public function list(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = auth('api')->user();
+
+        $mediaService = MediaService::make();
+        $layers = $user->favorite((new Layer)->getMorphClass())
+            ->map(function (Layer $layer) use ($mediaService) {
+                $firstMedia = $layer->getMedia()->first();
+
+                return [
+                    'id' => $layer->id,
+                    'title' => $layer->getTranslations('name'),
+                    'feature_image' => $firstMedia ? $mediaService->getThumbnailUrl($firstMedia) : '',
+                    'logo_image' => $layer->logo_image,
+                    'style' => ['color' => $layer->getStrokeColorHex()],
+                ];
+            })
+            ->values();
+
+        return response()->json(['favorites' => $layers]);
+    }
+}

--- a/src/Models/Layer.php
+++ b/src/Models/Layer.php
@@ -3,6 +3,7 @@
 namespace Wm\WmPackage\Models;
 
 use App\Models\User;
+use ChristianKuri\LaravelFavorite\Traits\Favoriteable;
 use Exception;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -22,7 +23,7 @@ use Wm\WmPackage\Traits\TaxonomyWhereAbleModel;
 
 class Layer extends Polygon
 {
-    use FeatureCollectionMapTrait, HasPackageFactory, HasTranslations, NormalizesHexColor, TaxonomyAbleModel, TaxonomyWhereAbleModel;
+    use Favoriteable, FeatureCollectionMapTrait, HasPackageFactory, HasTranslations, NormalizesHexColor, TaxonomyAbleModel, TaxonomyWhereAbleModel;
 
     public $timestamps = false;
 

--- a/src/Nova/App.php
+++ b/src/Nova/App.php
@@ -413,6 +413,10 @@ class App extends Resource
                 ->default(false)
                 ->hideFromIndex()
                 ->help(__('Shows the "Share" button on recorded UGC tracks (Instagram/Facebook Stories). Upload a Story frame image in the Release tab for branded compositing; falls back to an unbranded image otherwise.')),
+            Boolean::make(__('Show favorites'), 'properties->show_favorites')
+                ->default(false)
+                ->hideFromIndex()
+                ->help(__('Activate to show the favorite heart on layers and the "My favorites" section')),
 
             Tab::make('FEwebapp', $this->webapp_tab()),
             Tab::make('FE: mobile', $this->mobile_tab()),

--- a/src/Services/Models/App/AppConfigService.php
+++ b/src/Services/Models/App/AppConfigService.php
@@ -742,7 +742,7 @@ class AppConfigService extends AppBaseService
         $data['OPTIONS']['download_track_enable'] = $this->app->download_track_enable;
         $data['OPTIONS']['print_track_enable'] = $this->app->print_track_enable;
         $data['OPTIONS']['show_searchbar'] = $this->app->show_search;
-        $data['OPTIONS']['show_favorites'] = $this->app->show_favorites;
+        $data['OPTIONS']['showFavorites'] = (bool) ($this->app->properties['show_favorites'] ?? false);
         $data['OPTIONS']['show_scale'] = $this->app->table_details_show_scale;
         $data['OPTIONS']['showGpxDownload'] = $this->app->table_details_show_gpx_download;
         $data['OPTIONS']['showKmlDownload'] = $this->app->table_details_show_kml_download;

--- a/tests/Feature/AppConfigShowFavoritesTest.php
+++ b/tests/Feature/AppConfigShowFavoritesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Services\Models\App\AppConfigService;
+
+it('defaults show_favorites to false when not set in properties', function () {
+    $app = App::factory()->createQuietly(['properties' => []]);
+
+    $config = (new AppConfigService($app))->config();
+
+    expect($config['OPTIONS']['showFavorites'])->toBeFalse();
+});
+
+it('reads show_favorites true from properties', function () {
+    $app = App::factory()->createQuietly(['properties' => ['show_favorites' => true]]);
+
+    $config = (new AppConfigService($app))->config();
+
+    expect($config['OPTIONS']['showFavorites'])->toBeTrue();
+});

--- a/tests/Feature/LayerFavoriteControllerTest.php
+++ b/tests/Feature/LayerFavoriteControllerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Models\User;
+
+// Base TestCase (Wm\WmPackage\Tests\TestCase, with RefreshDatabase) is applied globally by
+// tests/Pest.php — no explicit uses() needed here.
+
+beforeEach(function () {
+    // Without this, `actingAs($user, 'api')` throws JWTException("Secret is not set.") as soon
+    // as the jwt guard tries to resolve a key — same fix already used by
+    // ShareStoryImageControllerTest.
+    $this->withoutMiddleware('auth.jwt');
+    $this->artisan('jwt:secret --always-no');
+});
+
+it('rejects an unauthenticated toggle request', function () {
+    $app = App::factory()->createQuietly();
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+
+    $response = $this->postJson("/api/layer/favorite/toggle/{$layer->id}");
+
+    $response->assertStatus(401);
+});
+
+it('adds a layer to favorites and is idempotent on repeated add', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+    $this->actingAs($user, 'api');
+
+    $response = $this->postJson("/api/layer/favorite/add/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => true]);
+
+    $response = $this->postJson("/api/layer/favorite/add/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => true]);
+
+    expect($layer->fresh()->isFavorited($user->id))->toBeTrue();
+});
+
+it('removes a layer from favorites and is idempotent on repeated remove', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+    $layer->toggleFavorite($user->id);
+    $this->actingAs($user, 'api');
+
+    $response = $this->postJson("/api/layer/favorite/remove/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => false]);
+
+    $response = $this->postJson("/api/layer/favorite/remove/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => false]);
+
+    expect($layer->fresh()->isFavorited($user->id))->toBeFalse();
+});
+
+it('toggles a layer favorite state back and forth', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+    $this->actingAs($user, 'api');
+
+    $response = $this->postJson("/api/layer/favorite/toggle/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => true]);
+
+    $response = $this->postJson("/api/layer/favorite/toggle/{$layer->id}");
+    $response->assertOk()->assertJson(['favorite' => false]);
+});
+
+it('lists the authenticated user favorite layers with a lightweight payload', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $favorited = Layer::factory()->create(['app_id' => $app->id, 'name' => ['it' => 'Cammino preferito', 'en' => 'Favorite path']]);
+    $notFavorited = Layer::factory()->create(['app_id' => $app->id]);
+    $favorited->toggleFavorite($user->id);
+    $this->actingAs($user, 'api');
+
+    $response = $this->getJson('/api/layer/favorite/list');
+
+    $response->assertOk();
+    $favorites = $response->json('favorites');
+    expect($favorites)->toHaveCount(1);
+    expect($favorites[0]['id'])->toBe($favorited->id);
+    expect($favorites[0]['title']['it'])->toBe('Cammino preferito');
+    expect($favorites[0])->toHaveKeys(['id', 'title', 'feature_image', 'logo_image', 'style']);
+    expect(collect($favorites)->pluck('id'))->not->toContain($notFavorited->id);
+});

--- a/tests/Feature/LayerFavoriteModelTest.php
+++ b/tests/Feature/LayerFavoriteModelTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Wm\WmPackage\Models\App;
+use Wm\WmPackage\Models\Layer;
+use Wm\WmPackage\Models\User;
+
+it('allows a user to favorite and unfavorite a layer', function () {
+    $app = App::factory()->createQuietly();
+    $user = User::factory()->create(['app_id' => $app->id]);
+    $layer = Layer::factory()->create(['app_id' => $app->id]);
+
+    expect($layer->isFavorited($user->id))->toBeFalse();
+
+    $layer->toggleFavorite($user->id);
+    expect($layer->fresh()->isFavorited($user->id))->toBeTrue();
+
+    $layer->toggleFavorite($user->id);
+    expect($layer->fresh()->isFavorited($user->id))->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- Adds `Favoriteable` trait to `Layer` (mirrors the existing `EcTrack` pattern) — no migration, reuses the existing `favorites` table.
- New `LayerFavoriteController` with `add`/`remove`/`toggle`/`list` endpoints under `auth:api`. `list()` returns a lightweight payload (id, title, thumbnail, logo, color) for the favorited layers.
- New `show_favorites` app-level flag, stored in `properties` (no migration), exposed as `OPTIONS.showFavorites` in config.json. Nova field added to the "Frontend" tab, below "Ugc Track Share Enabled".

## Test plan
- [x] `vendor/bin/pest tests/Feature/LayerFavoriteModelTest.php tests/Feature/LayerFavoriteControllerTest.php tests/Feature/AppConfigShowFavoritesTest.php` — 8/8 passing
- [ ] Enable `show_favorites` for the target app in Nova after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)